### PR TITLE
Interfaces konkreter UnitUIElements können über ihren type abgefragt werden

### DIFF
--- a/projects/common/unit.ts
+++ b/projects/common/unit.ts
@@ -16,9 +16,8 @@ export interface UnitPageSection {
   backgroundColor: string;
 }
 
-export interface UnitUIElement {
+export interface BasicUnitUIElement {
   [index: string]: string | number | boolean | string[],
-  type: string; // TODO maybe use enum or manual enumeration, because possible values are known
   id: string;
   xPosition: number;
   yPosition: number;
@@ -33,47 +32,69 @@ export interface UnitUIElement {
   underline: boolean;
 }
 
-export interface CompoundElementCorrection extends UnitUIElement {
+export type UnitUIElement =
+  CompoundElementCorrection |
+  LabelElement |
+  ButtonElement |
+  TextFieldElement |
+  CheckboxElement |
+  DropdownElement |
+  RadioButtonGroupElement |
+  ImageElement |
+  AudioElement |
+  VideoElement;
+
+export interface CompoundElementCorrection extends BasicUnitUIElement {
+  type: 'correction';
   text: string;
   sentences : string[];
 }
 
-export interface LabelElement extends UnitUIElement {
+export interface LabelElement extends BasicUnitUIElement {
+  type: 'label';
   label: string;
 }
 
-export interface ButtonElement extends UnitUIElement {
+export interface ButtonElement extends BasicUnitUIElement {
+  type: 'button';
   label: string;
 }
 
-export interface TextFieldElement extends UnitUIElement {
+export interface TextFieldElement extends BasicUnitUIElement {
+  type: 'text-field';
   placeholder: string;
   multiline: boolean;
 }
 
-export interface CheckboxElement extends UnitUIElement {
+export interface CheckboxElement extends BasicUnitUIElement {
+  type: 'checkbox';
   label: string;
 }
 
-export interface DropdownElement extends UnitUIElement {
+export interface DropdownElement extends BasicUnitUIElement {
+  type: 'dropdown';
   label: string;
   options: string[];
 }
 
-export interface RadioButtonGroupElement extends UnitUIElement {
+export interface RadioButtonGroupElement extends BasicUnitUIElement {
+  type: 'radio';
   text: string;
   options: string[];
   alignment: 'row' | 'column';
 }
 
-export interface ImageElement extends UnitUIElement {
+export interface ImageElement extends BasicUnitUIElement {
+  type: 'image';
   src: string;
 }
 
-export interface AudioElement extends UnitUIElement {
+export interface AudioElement extends BasicUnitUIElement {
+  type: 'audio';
   src: string;
 }
 
-export interface VideoElement extends UnitUIElement {
+export interface VideoElement extends BasicUnitUIElement {
+  type: 'video';
   src: string;
 }

--- a/projects/editor/src/app/model/UnitFactory.ts
+++ b/projects/editor/src/app/model/UnitFactory.ts
@@ -2,7 +2,7 @@ import {
   AudioElement, ButtonElement,
   CheckboxElement, CompoundElementCorrection, DropdownElement,
   ImageElement, LabelElement, RadioButtonGroupElement,
-  TextFieldElement, Unit, UnitPage, UnitPageSection, UnitUIElement,
+  TextFieldElement, Unit, UnitPage, UnitPageSection, BasicUnitUIElement,
   VideoElement
 } from '../../../../common/unit';
 
@@ -30,9 +30,8 @@ export function createUnitPageSection(): UnitPageSection {
   };
 }
 
-export function createUnitUIElement(type: string): UnitUIElement {
+export function createUnitUIElement(): BasicUnitUIElement {
   return {
-    type,
     id: 'dummyID',
     xPosition: 0,
     yPosition: 0,
@@ -51,75 +50,85 @@ export function createUnitUIElement(type: string): UnitUIElement {
 export function createLabelElement(): LabelElement {
   return {
     label: 'Label Text',
-    ...createUnitUIElement('label')
+    type: 'label',
+    ...createUnitUIElement()
   };
 }
 
 export function createButtonElement(): ButtonElement {
   return {
     label: 'Button Text',
-    ...createUnitUIElement('button')
+    type: 'button',
+    ...createUnitUIElement()
   };
 }
 
 export function createTextfieldElement(): TextFieldElement {
   return {
+    type: 'text-field',
     placeholder: 'DUMMY',
     multiline: true,
-    ...createUnitUIElement('text-field')
+    ...createUnitUIElement()
   };
 }
 
 export function createCheckboxElement(): CheckboxElement {
   return {
+    type: 'checkbox',
     label: 'Label Checkbox',
-    ...createUnitUIElement('checkbox')
+    ...createUnitUIElement()
   };
 }
 
 export function createDropdownElement(): DropdownElement {
   return {
+    type: 'dropdown',
     label: 'Label Dropdown',
     options: [],
-    ...createUnitUIElement('dropdown')
+    ...createUnitUIElement()
   };
 }
 
 export function createRadioButtonGroupElement(): RadioButtonGroupElement {
   return {
+    type: 'radio',
     text: 'Label Optionsfeld',
     options: [],
     alignment: 'row',
-    ...createUnitUIElement('radio'),
+    ...createUnitUIElement(),
     height: 75
   };
 }
 
 export function createImageElement(imageSrc: string): ImageElement {
   return {
+    type: 'image',
     src: imageSrc,
-    ...createUnitUIElement('image')
+    ...createUnitUIElement()
   };
 }
 
 export function createAudioElement(audioSrc: string): AudioElement {
   return {
+    type: 'audio',
     src: audioSrc,
-    ...createUnitUIElement('audio')
+    ...createUnitUIElement()
   };
 }
 
 export function createVideoElement(videoSrc: string): VideoElement {
   return {
+    type: 'video',
     src: videoSrc,
-    ...createUnitUIElement('video')
+    ...createUnitUIElement()
   };
 }
 
 export function createCorrectionElement(): CompoundElementCorrection {
   return {
+    type: 'correction',
     text: 'dummy',
     sentences: [],
-    ...createUnitUIElement('correction')
+    ...createUnitUIElement()
   };
 }


### PR DESCRIPTION
Die impementierten Maßnahmen ermöglichen folgende Konstruktion:

```
exampleFunction(element: UnitUIElement): void {
  if (element.type === 'button') {
     console.log(element.label)
  }
}
```
Die bisherige Implementierung würde bei einer solchen Konstruktion einen Fehler werfen, da nicht alle Interfaces konkreter UnitUIElemente die property `label` implementieren