### PR TITLE
[audio][video] Adjust horizontal alignment of icons in control buttons

### DIFF
--- a/projects/common/components/media-elements/media-player-control-bar/media-player-control-bar.component.scss
+++ b/projects/common/components/media-elements/media-player-control-bar/media-player-control-bar.component.scss
@@ -38,6 +38,7 @@
     font-size: 24px;
     width: 24px;
     height: 24px;
+    padding-left: 5px;
   }
 }
 


### PR DESCRIPTION
Since the update to Angular 20, the icons in buttons behave slightly differently. In older versions, the width of the control buttons was adjusted when the control bar was reduced to the play control. The newly added padding produces a similar, acceptable result.