### PR TITLE
Fix table element bugs in editor and player

### DIFF
--- a/e2e/tests/e2e/assistant-droplist-selection.spec.cy.ts
+++ b/e2e/tests/e2e/assistant-droplist-selection.spec.cy.ts
@@ -1,0 +1,53 @@
+import {
+  addElement, addNewSection, submitDialog, switchToPositionTab
+} from '../util';
+import {
+  openAssistant,
+  typeInRichTextEditor,
+  addOptionViaFormField
+} from './helpers/assistant-util';
+
+/* The two-sided droplist prepends an always visible page, which shifts every page index by one.
+   A selection pointing at anything but the first section used to survive that shift unchanged and
+   then addressed a section that does not exist on the newly prepended page. */
+describe('Droplist assistant selection handling', { testIsolation: false }, () => {
+  before('opens an editor', () => {
+    cy.openEditor();
+  });
+
+  it('creates a two-sided droplist while a section other than the first one is selected', () => {
+    addNewSection();
+    addElement('Text');
+
+    openAssistant('Drag & Drop');
+    cy.get('mat-dialog-container').contains('button', 'Zuordnung (2-seitig)').click();
+
+    typeInRichTextEditor('Zuordnung 2-seitig!', 0);
+    typeInRichTextEditor('Zweiseitige Startliste', 1);
+    addOptionViaFormField('Text Option A', 0);
+    addOptionViaFormField('Text Option B', 0);
+    typeInRichTextEditor('Situierungstext', 2);
+    typeInRichTextEditor('Zweiseitige Zielliste', 3);
+    addOptionViaFormField('Text Target X', 1);
+    addOptionViaFormField('Text Target Y', 1);
+    typeInRichTextEditor('Quellentext', 4);
+
+    submitDialog();
+
+    cy.contains('Unerwarteter Fehler').should('not.exist');
+    cy.get('mat-dialog-container').should('not.exist');
+  });
+
+  it('creates the always visible page and keeps the pre-existing element', () => {
+    cy.contains('dauerhaft sichtbare Seite').should('exist');
+    cy.contains('aspect-text', 'Zweiseitige Zielliste').should('exist');
+    // The regular pages live on their own lazily rendered tab
+    cy.contains('.mat-mdc-tab', 'Seiten').click();
+    cy.contains('aspect-text', 'Zweiseitige Startliste').should('exist');
+  });
+
+  it('shows the position properties of the selected element', () => {
+    switchToPositionTab();
+    cy.get('aspect-position-field-set').should('exist');
+  });
+});

--- a/e2e/tests/e2e/table.spec.cy.ts
+++ b/e2e/tests/e2e/table.spec.cy.ts
@@ -55,6 +55,22 @@ describe('Table element', { testIsolation: false }, () => {
             saveTableEditDialog();
         });
 
+        it('updates the canvas checkbox display when toggling its preset value', () => {
+            // Select the checkbox child element on the canvas
+            cy.get('aspect-table aspect-checkbox').closest('.wrapper').click();
+
+            cy.get('aspect-element-model-properties-component mat-button-toggle-group')
+                .contains('mat-button-toggle', 'wahr').click();
+            cy.get('aspect-table aspect-checkbox .svg-checkbox-cross')
+                .should('have.attr', 'style').and('match', /opacity: 1/);
+
+            // Reset, so the player tests below start with an unchecked checkbox
+            cy.get('aspect-element-model-properties-component mat-button-toggle-group')
+                .contains('mat-button-toggle', 'falsch').click();
+            cy.get('aspect-table aspect-checkbox .svg-checkbox-cross')
+                .should('have.attr', 'style').and('match', /opacity: 0/);
+        });
+
         after('saves unit definition', () => {
             cy.saveUnit('e2e/downloads/table.json');
         });

--- a/e2e/tests/e2e/table.spec.cy.ts
+++ b/e2e/tests/e2e/table.spec.cy.ts
@@ -1,4 +1,4 @@
-import { addElement, setCheckbox } from '../util';
+import { addElement, setCheckbox, switchToPositionTab } from '../util';
 import {
     createTable,
     openTableEditDialog,
@@ -14,6 +14,16 @@ describe('Table element', { testIsolation: false }, () => {
 
         it('creates a default 2x2 table without borders', () => {
             createTable('table-default', 2, 2, false);
+        });
+
+        it('presets the bottom margin of a new table with 30px', () => {
+            // The raw-number registry default used to reach the position group unconverted,
+            // leaving new tables without their bottom margin until the next reload (#1061)
+            switchToPositionTab();
+            cy.contains('aspect-size-input-panel', 'unten').find('input[type="number"]')
+                .should('have.value', '30');
+            // Switch the properties panel back to the model tab for the following tests
+            cy.get('.mat-mdc-tab').contains('mat-icon', 'build').click({ force: true });
         });
 
         it('does not show add/remove buttons on the canvas', () => {

--- a/e2e/tests/e2e/table.spec.cy.ts
+++ b/e2e/tests/e2e/table.spec.cy.ts
@@ -129,6 +129,17 @@ describe('Table element', { testIsolation: false }, () => {
                 .should('have.value', 'Tabelleneintrag');
         });
 
+        it('shows an inset focus ring on the focused table text-field', () => {
+            // The ring must lie inside the cell, otherwise neighboring cells cover it (#1069)
+            cy.get('aspect-table').eq(1)
+                .find('aspect-text-field input')
+                .focus()
+                .should('have.css', 'outline-style', 'solid')
+                .and('have.css', 'outline-offset', '-2px')
+                // indigo-pink theme primary, like the focused mat-form-field
+                .and('have.css', 'outline-color', 'rgb(63, 81, 181)');
+        });
+
         it('second table contains a checkbox and allows checking', () => {
             cy.get('aspect-table').eq(1)
                 .find('aspect-checkbox')

--- a/e2e/tests/e2e/table.spec.cy.ts
+++ b/e2e/tests/e2e/table.spec.cy.ts
@@ -16,6 +16,13 @@ describe('Table element', { testIsolation: false }, () => {
             createTable('table-default', 2, 2, false);
         });
 
+        it('does not show add/remove buttons on the canvas', () => {
+            // Add/remove buttons must only appear in the "Elemente anpassen" dialog,
+            // where their events are handled (#1053, #1060)
+            cy.get('aspect-table').should('exist');
+            cy.get('aspect-table button').should('not.exist');
+        });
+
         it('creates a 2x3 table with borders and adds child elements', () => {
             addElement('Tabelle', 'Verbund', 'table-with-content');
 

--- a/projects/common/assets/customTheme.scss
+++ b/projects/common/assets/customTheme.scss
@@ -27,6 +27,12 @@ aspect-editor-dynamic-overlay, aspect-player {
 $aspect-element-border-color: #ccc;
 $aspect-element-border-hover-color: #333;
 
+:root {
+  // Focus indicator color of custom inputs, matching the focused
+  // mat-form-field of the loaded prebuilt theme (indigo-pink primary)
+  --outline-color-primary: #3f51b5;
+}
+
 .mat-button-toggle-group-appearance-standard {
   border-color: $aspect-element-border-color;
   .mat-button-toggle+.mat-button-toggle {
@@ -42,6 +48,6 @@ math-field {
     border-color: $aspect-element-border-hover-color
   };
   &:focus {
-    outline-color: #3f51b5; //TODO $outline-color-primary
+    outline-color: var(--outline-color-primary);
   }
 }

--- a/projects/common/components/compound-elements/table/table.component.ts
+++ b/projects/common/components/compound-elements/table/table.component.ts
@@ -38,7 +38,7 @@ import { UIElementType } from 'common/interfaces';
            [style.border-radius.px]="elementModel.styling.borderRadius"
            [style.grid-row-start]="i + 1"
            [style.grid-column-start]="j + 1">
-        <ng-container *ngIf="elementGrid[i][j] === undefined && editorMode">
+        <ng-container *ngIf="elementGrid[i][j] === undefined && allowElementEditing">
           <button mat-mini-fab color="primary" class="button"
                   [matMenuTriggerFor]="menu">
             <mat-icon>add</mat-icon>
@@ -54,11 +54,9 @@ import { UIElementType } from 'common/interfaces';
           </mat-menu>
         </ng-container>
         <div *ngIf="elementGrid[i][j] !== undefined" class="element-container">
-          <div class="element-title">
-            <ng-container *ngIf="editorMode">
-              {{$any($any(elementGrid[i][j]).constructor).title}}
-            </ng-container>
-            <ng-container *ngIf="editorMode && $any(elementGrid[i][j]).alias !== 'alias-placeholder'">
+          <div *ngIf="allowElementEditing" class="element-title">
+            {{$any($any(elementGrid[i][j]).constructor).title}}
+            <ng-container *ngIf="$any(elementGrid[i][j]).alias !== 'alias-placeholder'">
               - {{$any(elementGrid[i][j]).alias}}
             </ng-container>
           </div>
@@ -71,7 +69,7 @@ import { UIElementType } from 'common/interfaces';
                                       [editorMode]="editorMode"
                                       (elementSelected)="childElementSelected.emit($event)">
           </aspect-table-child-overlay>
-          <button *ngIf="editorMode" class="remove-button" mat-mini-fab color="primary"
+          <button *ngIf="allowElementEditing" class="remove-button" mat-mini-fab color="primary"
                   (click)="removeElement(i, j)">
             <mat-icon>remove</mat-icon>
           </button>
@@ -106,6 +104,9 @@ export class TableComponent extends CompoundElementComponent implements OnInit {
   @Input() actualPlayingId!: Subject<string | null>;
   @Input() mediaStatusChanged!: Subject<string>;
   @Input() editorMode: boolean = false;
+  /* Show add/remove buttons and element titles for managing cell elements.
+     Only enabled in the table edit dialog, where the corresponding events are handled. */
+  @Input() allowElementEditing: boolean = false;
   @Output() elementAdded = new EventEmitter<{ elementType: UIElementType, row: number, col: number }>();
   @Output() elementRemoved = new EventEmitter<{ row: number, col: number }>();
   @Output() childElementSelected = new EventEmitter<TableChildOverlay>();

--- a/projects/common/components/input-elements/checkbox.component.ts
+++ b/projects/common/components/input-elements/checkbox.component.ts
@@ -38,7 +38,10 @@ import { FormElementComponent } from '../../directives/form-element-component.di
            [class.read-only] = "elementModel.readOnly"
            [class.errors]="elementFormControl.errors && elementFormControl.touched"
            (click)="elementFormControl.markAsTouched(); elementFormControl.setValue(!elementFormControl.value)">
-        <svg class="svg-checkbox-cross" [style.opacity]="elementFormControl.value ? 1 : 0" viewBox='0 0 100 100'>
+        <!-- Without parentForm (editor mode) the control is never updated, so mirror the model value -->
+        <svg class="svg-checkbox-cross"
+             [style.opacity]="(parentForm ? elementFormControl.value : elementModel.value) ? 1 : 0"
+             viewBox='0 0 100 100'>
           <path d='M1 0 L0 1 L99 100 L100 99' fill='black' stroke="black" stroke-width="2" />
           <path d='M0 99 L99 0 L100 1 L1 100' fill='black' stroke="black" stroke-width="1" />
         </svg>

--- a/projects/common/components/input-elements/text-area.component.ts
+++ b/projects/common/components/input-elements/text-area.component.ts
@@ -106,6 +106,12 @@ import { TextInputComponent } from 'common/directives/text-input-component.direc
       padding: 0 10px;
       font-family: inherit;
     }
+    /* The textarea fills the whole table cell, so the native focus ring would be
+       painted into the neighboring cells and get covered by them. Draw it inset instead. */
+    .table-child:focus-visible {
+      outline: 2px solid var(--outline-color-primary);
+      outline-offset: -2px;
+    }
     .errors {
       border: 2px solid #f44336 !important;
     }

--- a/projects/common/components/input-elements/text-field.component.ts
+++ b/projects/common/components/input-elements/text-field.component.ts
@@ -108,6 +108,12 @@ import { TextInputComponent } from 'common/directives/text-input-component.direc
       padding: 0 10px;
       font-family: inherit;
     }
+    /* The input fills the whole table cell, so the native focus ring would be
+       painted into the neighboring cells and get covered by them. Draw it inset instead. */
+    .table-child:focus-visible {
+      outline: 2px solid var(--outline-color-primary);
+      outline-offset: -2px;
+    }
     .errors {
       border: 2px solid #f44336 !important;
     }

--- a/projects/common/models/elements/element-registry.ts
+++ b/projects/common/models/elements/element-registry.ts
@@ -352,7 +352,7 @@ export const ELEMENT_DEFAULTS: Record<string, Record<string, unknown>> = {
     gridRowSizes: [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }],
     elements: [],
     tableEdgesEnabled: false,
-    marginBottom: 30,
+    marginBottom: { value: 30, unit: 'px' },
     borderWidth: 1,
     backgroundColor: 'transparent'
   },

--- a/projects/common/utils/element-factory.spec.ts
+++ b/projects/common/utils/element-factory.spec.ts
@@ -81,6 +81,16 @@ describe('ElementFactory', () => {
     expect(table.dimensions?.height).toBe(333);
   });
 
+  it('should preset the table bottom margin as a measurement object', () => {
+    // The registry default was a raw number, which the position generator passed through,
+    // so new tables came without the intended 30px bottom margin until the next reload (#1061)
+    const table = ElementFactory.createElement({
+      type: 'table',
+      elements: []
+    } as unknown as UIElementProperties);
+    expect(table.position?.marginBottom).toEqual({ value: 30, unit: 'px' });
+  });
+
   it('should keep common input properties when instantiating from a non-empty partial blueprint', () => {
     // A non-null partial blueprint passes the simplified type guards, so the constructor body runs
     // and must not overwrite the base-class defaults (readOnly, required, ...) with undefined.

--- a/projects/editor/src/app/components/dialogs/table-edit-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/table-edit-dialog.component.ts
@@ -27,7 +27,7 @@ import { firstValueFrom } from 'rxjs';
   template: `
     <div mat-dialog-title>Tabellenelemente</div>
     <mat-dialog-content>
-      <aspect-table [elementModel]="newTable" [editorMode]="true"
+      <aspect-table [elementModel]="newTable" [editorMode]="true" [allowElementEditing]="true"
                     (elementAdded)="addElement($event)"
                     (elementRemoved)="removeElement($event)"></aspect-table>
     </mat-dialog-content>

--- a/projects/editor/src/app/section-templates/template.service.ts
+++ b/projects/editor/src/app/section-templates/template.service.ts
@@ -62,16 +62,22 @@ export class TemplateService {
 
     const selectedPage = this.unitService.getSelectedPage();
     const selectedSectionIndex = this.selectionService.selectedSectionIndex;
+    let targetPage: EditorPage;
+    let targetSectionIndex: number;
     if (!Array.isArray(templateSections)) {
-      TemplateService.addSectionToPage(templateSections, selectedPage, selectedSectionIndex);
+      targetPage = selectedPage;
+      targetSectionIndex = TemplateService.addSectionToPage(templateSections, targetPage, selectedSectionIndex);
     } else {
-      const targetPage = selectedPage.alwaysVisible ? this.unitService.unit.pages[1] : selectedPage;
+      targetPage = selectedPage.alwaysVisible ? this.unitService.unit.pages[1] : selectedPage;
       if (!this.unitService.unit.pages[0].alwaysVisible) {
         this.createAlwaysVisiblePage();
       }
       TemplateService.addSectionToPage(templateSections[1], this.unitService.unit.pages[0], 0);
-      TemplateService.addSectionToPage(templateSections[0], targetPage, selectedSectionIndex);
+      targetSectionIndex = TemplateService.addSectionToPage(templateSections[0], targetPage, selectedSectionIndex);
     }
+    /* Adding the always visible page shifts all page indices, so the selection has to be updated.
+       Otherwise it can point at a section which does not exist on the newly selected page. */
+    this.selectionService.updateSelection(this.unitService.unit.pages.indexOf(targetPage), targetSectionIndex);
     this.unitService.updateSectionCounter();
     this.unitService.updateUnitDefinition();
   }
@@ -82,12 +88,14 @@ export class TemplateService {
     this.unitService.pageOrderChanged.next();
   }
 
-  private static addSectionToPage(section: EditorSection, page: EditorPage, selectedSectionIndex: number): void {
-    if (page.sections[selectedSectionIndex].isEmpty()) {
+  /* Returns the index the section was put at. */
+  private static addSectionToPage(section: EditorSection, page: EditorPage, selectedSectionIndex: number): number {
+    if (page.sections[selectedSectionIndex]?.isEmpty()) {
       page.replaceSection(selectedSectionIndex, section);
-    } else {
-      page.addSection(section);
+      return selectedSectionIndex;
     }
+    page.addSection(section);
+    return page.sections.length - 1;
   }
 
   private createTemplateSections(templateName: string): Promise<EditorSection | [EditorSection, EditorSection]> {


### PR DESCRIPTION
## Summary

Collection of table-related fixes (plus one template-assistant fix that was pending on this branch):

- **Show table add/remove buttons only in the edit dialog** (#1053, #1060): Since the prevent-interaction fix set `editorMode` on canvas tables, add/remove buttons and element titles appeared on the canvas, where their events were never handled — selecting an element type did nothing. They are now gated behind a new `allowElementEditing` input that only the "Elemente anpassen" dialog enables, restoring the pre-3.0.0-beta behavior.
- **Mirror model value in table checkbox display in editor mode**: The SVG cross of a table checkbox was bound only to the FormControl, which never receives updates without a parentForm, so setting the preset value in the properties panel did not change the display.
- **Draw inset focus ring on table text inputs** (#1069): Text fields/areas inside a table fill their cell completely, so the native focus outline was painted into neighboring cells and partially covered. Replaced with a uniform 2px ring drawn inside the input via negative `outline-offset`, using the new global `--outline-color-primary` variable (indigo-pink theme primary, also resolves the TODO at the math-field focus style).
- **Preset new tables with their 30px bottom margin** (#1061): The table entry in `ELEMENT_DEFAULTS` carried `marginBottom` as a raw number instead of a measurement object, so new tables had no bottom margin until the normalizer converted it on the next load.
- **Update selection after inserting section templates**: Two-page templates prepend the always visible page, which shifts every page index; the selection kept its old indices and could point at a no longer matching section.

## Test plan

- [x] E2E: `table.spec.cy.ts` extended to 14 tests (canvas button absence, checkbox preset display, focus ring, margin preset) — all passing
- [x] E2E: new `assistant-droplist-selection.spec.cy.ts` (3 tests) — all passing
- [x] Unit: `element-factory.spec.ts` extended, full `common` suite 121/121 passing
- [x] Editor and player builds pass

Closes #1053, closes #1060, closes #1061, closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)