### PR TITLE
[editor][tipTap] Suppress formatting on paste and drop

### DIFF
--- a/e2e/tests/editor/text-editor-paste.spec.cy.ts
+++ b/e2e/tests/editor/text-editor-paste.spec.cy.ts
@@ -1,0 +1,54 @@
+import { addElement } from '../util';
+
+describe('Rich text editor paste', () => {
+  beforeEach(() => {
+    cy.viewport(1300, 800);
+    cy.openEditor();
+    addElement('Text');
+    cy.get('aspect-element-model-properties-component').contains('edit').click();
+    cy.get('mat-dialog-container .ProseMirror').as('editor');
+  });
+
+  afterEach(() => {
+    cy.contains('Speichern').click();
+  });
+
+  it('pastes formatted clipboard content as plain text', () => {
+    cy.get('@editor').trigger('paste', {
+      clipboardData: {
+        getData: (type: string) => {
+          if (type === 'text/plain') return 'Hallo Welt';
+          if (type === 'text/html') return '<p><strong style="color: red;">Hallo Welt</strong></p>';
+          return '';
+        }
+      }
+    });
+
+    cy.get('@editor').should('contain.text', 'Hallo Welt');
+    cy.get('@editor').find('strong').should('not.exist');
+  });
+
+  it('pastes multi-line text as separate paragraphs', () => {
+    cy.get('@editor').trigger('paste', {
+      clipboardData: {
+        getData: (type: string) => (type === 'text/plain' ? 'Zeile 1\nZeile 2' : '')
+      }
+    });
+
+    cy.get('@editor').find('p').contains('Zeile 1').should('exist');
+    cy.get('@editor').find('p').contains('Zeile 2').should('exist');
+  });
+
+  it('pastes HTML-only clipboard content as plain text', () => {
+    cy.get('@editor').trigger('paste', {
+      clipboardData: {
+        getData: (type: string) => (type === 'text/html' ? '<h1>Titel</h1><p><em>kursiv</em></p>' : '')
+      }
+    });
+
+    cy.get('@editor').should('contain.text', 'Titel');
+    cy.get('@editor').should('contain.text', 'kursiv');
+    cy.get('@editor').find('h1').should('not.exist');
+    cy.get('@editor').find('em').should('not.exist');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "katex": "^0.16.11",
         "ngx-tiptap": "^11.1.0",
         "ngx-translate-testing": "^7.0.0",
+        "prosemirror-model": "^1.25.4",
         "prosemirror-state": "^1.4.3",
         "prosemirror-view": "^1.41.3",
         "rxjs": "^7.8.1",
@@ -1860,15 +1861,15 @@
       }
     },
     "node_modules/@angular/build/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@angular/build/node_modules/@vitejs/plugin-basic-ssl": {
@@ -2216,9 +2217,9 @@
       }
     },
     "node_modules/@angular/build/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "katex": "^0.16.11",
     "ngx-tiptap": "^11.1.0",
     "ngx-translate-testing": "^7.0.0",
+    "prosemirror-model": "^1.25.4",
     "prosemirror-state": "^1.4.3",
     "prosemirror-view": "^1.41.3",
     "rxjs": "^7.8.1",

--- a/projects/editor/src/app/text-editor/rich-text-editor.component.spec.ts
+++ b/projects/editor/src/app/text-editor/rich-text-editor.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogService } from 'editor/src/app/services/dialog.service';
+import { RichTextEditorComponent } from './rich-text-editor.component';
+
+describe('RichTextEditorComponent', () => {
+  let component: RichTextEditorComponent;
+  let fixture: ComponentFixture<RichTextEditorComponent>;
+
+  const createClipboardEvent = (data: Record<string, string>): ClipboardEvent => {
+    const clipboardData = new DataTransfer();
+    Object.entries(data).forEach(([type, value]) => clipboardData.setData(type, value));
+    return new ClipboardEvent('paste', { clipboardData, cancelable: true, bubbles: true });
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RichTextEditorComponent],
+      providers: [{ provide: DialogService, useValue: {} }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RichTextEditorComponent);
+    component = fixture.componentInstance;
+    component.content = '';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should paste formatted clipboard content as plain text', () => {
+    component.editor.view.dom.dispatchEvent(createClipboardEvent({
+      'text/plain': 'Hallo Welt',
+      'text/html': '<p><strong style="color: red;">Hallo Welt</strong></p>'
+    }));
+
+    const html = component.editor.getHTML();
+    expect(html).toContain('Hallo Welt');
+    expect(html).not.toContain('<strong');
+    expect(html).not.toContain('color');
+  });
+
+  it('should paste multi-line text as separate paragraphs', () => {
+    component.editor.view.dom.dispatchEvent(createClipboardEvent({
+      'text/plain': 'Zeile 1\r\nZeile 2\nZeile 3'
+    }));
+
+    const doc = component.editor.state.doc;
+    expect(doc.childCount).toBe(3);
+    expect(doc.child(0).textContent).toBe('Zeile 1');
+    expect(doc.child(1).textContent).toBe('Zeile 2');
+    expect(doc.child(2).textContent).toBe('Zeile 3');
+  });
+
+  it('should paste HTML-only clipboard content as plain text', () => {
+    component.editor.view.dom.dispatchEvent(createClipboardEvent({
+      'text/html': '<h1>Titel</h1><p>Erster Absatz<br>mit Umbruch</p>'
+    }));
+
+    const html = component.editor.getHTML();
+    expect(html).not.toContain('<h1');
+    expect(html).not.toContain('<br');
+    expect(component.editor.state.doc.textContent).toContain('Titel');
+    expect(component.editor.state.doc.textContent).toContain('Erster Absatz');
+    expect(component.editor.state.doc.textContent).toContain('mit Umbruch');
+  });
+
+  it('should insert dropped text as plain text', () => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', 'Angekommen');
+    dataTransfer.setData('text/html', '<p><em>Angekommen</em></p>');
+    const coords = component.editor.view.coordsAtPos(1);
+    component.editor.view.dom.dispatchEvent(new DragEvent('drop', {
+      dataTransfer,
+      clientX: coords.left,
+      clientY: coords.top,
+      cancelable: true,
+      bubbles: true
+    }));
+
+    const html = component.editor.getHTML();
+    expect(html).toContain('Angekommen');
+    expect(html).not.toContain('<em');
+  });
+});

--- a/projects/editor/src/app/text-editor/rich-text-editor.component.ts
+++ b/projects/editor/src/app/text-editor/rich-text-editor.component.ts
@@ -39,6 +39,7 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
 import { ComboButtonComponent } from 'editor/src/app/components/util/combo-button.component';
 import { CharacterCount } from '@tiptap/extension-character-count';
 import { EditorView } from 'prosemirror-view';
+import { Fragment, Slice } from 'prosemirror-model';
 import { AnchorId } from './extensions/anchorId';
 import { Indent } from './extensions/indent';
 import { HangingIndent } from './extensions/hanging-indent';
@@ -153,20 +154,56 @@ export class RichTextEditorComponent implements OnInit, AfterViewInit {
           placeholder: this.placeholder
         })],
       editorProps: {
-        handlePaste: RichTextEditorComponent.handlePastePlainText
+        handlePaste: RichTextEditorComponent.handlePastePlainText,
+        handleDrop: RichTextEditorComponent.handleDropPlainText
       }
     });
   }
 
   private static handlePastePlainText(view: EditorView, event: ClipboardEvent): boolean {
-    const text = event.clipboardData?.getData('text/plain') ?? '';
+    const text = RichTextEditorComponent.getPlainText(event.clipboardData);
     if (!text) return false;
     event.preventDefault();
-    // Insert sanitized plain text
-    const { state, dispatch } = view;
-    const { from, to } = state.selection;
-    dispatch(state.tr.insertText(text, from, to));
+    const { from, to } = view.state.selection;
+    RichTextEditorComponent.insertPlainText(view, text, from, to);
     return true;
+  }
+
+  private static handleDropPlainText(view: EditorView, event: DragEvent, slice: Slice, moved: boolean): boolean {
+    if (moved) return false; // keep default behavior when dragging content within the editor
+    const text = RichTextEditorComponent.getPlainText(event.dataTransfer);
+    if (!text) return false;
+    const dropPos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos;
+    if (dropPos === undefined) return false;
+    event.preventDefault();
+    RichTextEditorComponent.insertPlainText(view, text, dropPos, dropPos);
+    return true;
+  }
+
+  private static getPlainText(data: DataTransfer | null): string {
+    const text = data?.getData('text/plain');
+    if (text) return text;
+    // Some sources only provide HTML; strip all markup and keep line breaks
+    const html = data?.getData('text/html');
+    if (!html) return '';
+    const htmlWithLineBreaks = html
+      .replace(/<br[^>]*>/gi, '\n')
+      .replace(/<\/(p|div|li|tr|h[1-6]|blockquote)>/gi, '\n');
+    return new DOMParser().parseFromString(htmlWithLineBreaks, 'text/html').body.textContent?.trim() ?? '';
+  }
+
+  private static insertPlainText(view: EditorView, text: string, from: number, to: number): void {
+    const { state, dispatch } = view;
+    const lines = text.split(/\r\n?|\n/);
+    if (lines.length === 1) {
+      dispatch(state.tr.insertText(text, from, to));
+      return;
+    }
+    const paragraphs = lines.map(line => state.schema.nodes.paragraph.create(
+      null, line ? state.schema.text(line) : undefined
+    ));
+    const slice = new Slice(Fragment.fromArray(paragraphs), 1, 1);
+    dispatch(state.tr.replaceRange(from, to, slice).scrollIntoView());
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
Closes #915

## Kontext

Der zentrale `RichTextEditorComponent` (von allen Tiptap-Stellen genutzt: Text-Dialog, Lückentext, reduzierte Variante für Labels/Optionen/Stimulus) fügt seit #682 bereits Plain Text ein. Es gab aber noch drei Lücken, über die Formatierungen aus Word-/PDF-Dokumenten hereinkamen bzw. Ärger machten.

## Änderungen

- **Clipboard ohne `text/plain`**: Bisher fiel der Handler auf das formatierte Standard-Einfügen zurück. Jetzt wird der Text aus `text/html` extrahiert (Tags entfernt, `<br>`/Blockenden werden zu Zeilenumbrüchen). Enthält die Zwischenablage gar keinen Text (z. B. internes Kopieren von Cloze-Knoten, Bilder), bleibt das Standardverhalten erhalten.
- **Drag & Drop**: Extern hereingezogener formatierter Text lief bisher komplett am Paste-Handler vorbei. Ein neuer `handleDrop`-Handler fügt ihn als Plain Text ein; internes Verschieben innerhalb des Editors (`moved`) bleibt unangetastet.
- **Mehrzeiliger Text**: Statt roher `\n` in einem einzigen Absatz (die im Player zu Leerzeichen kollabieren) werden jetzt echte Absätze erzeugt — analog zum nativen ProseMirror-Plain-Text-Paste.
- `prosemirror-model` als direkte Dependency ergänzt.

## Tests

- Neue Komponententests (`rich-text-editor.component.spec.ts`): echte `paste`-/`drop`-Events gegen den voll initialisierten Editor — 52/52 Editor-Unit-Tests grün.
- Neue E2E-Spec (`e2e/tests/editor/text-editor-paste.spec.cy.ts`): Paste in den „Text bearbeiten"-Dialog im echten Browser — alle Editor-E2E-Specs grün (40/40).
- `ng build editor` und ESLint sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)