### PR TITLE
Fix image resize dialog: aspect ratio handling and WebP conversion

### DIFF
--- a/projects/common/services/file.service.spec.ts
+++ b/projects/common/services/file.service.spec.ts
@@ -1,0 +1,66 @@
+import { FileService } from './file.service';
+
+describe('FileService', () => {
+  const createImage = (width: number, height: number, mimeType: string = 'image/png'): string => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(0, 0, width, height);
+    return canvas.toDataURL(mimeType);
+  };
+
+  const getImageDimensions = (base64: string): Promise<{ width: number; height: number }> => new Promise(resolve => {
+    const img = new Image();
+    img.src = base64;
+    img.onload = () => resolve({ width: img.width, height: img.height });
+  });
+
+  describe('scaleImage', () => {
+    it('should return the original image when no resize and no conversion is needed', async () => {
+      const source = createImage(10, 10);
+      const result = await FileService.scaleImage(source, { maxWidth: 100, maxHeight: 100 });
+      expect(result).toBe(source);
+    });
+
+    it('should convert to WebP even when the dimensions stay the same', async () => {
+      const source = createImage(10, 10);
+      const result = await FileService
+        .scaleImage(source, { maxWidth: 10, maxHeight: 10, targetMimeType: 'image/webp' });
+      expect(result.startsWith('data:image/webp')).toBeTrue();
+    });
+
+    it('should convert to WebP without upscaling when the max dimensions are larger', async () => {
+      const source = createImage(10, 10);
+      const result = await FileService
+        .scaleImage(source, { maxWidth: 100, maxHeight: 100, targetMimeType: 'image/webp' });
+      expect(result.startsWith('data:image/webp')).toBeTrue();
+      const dimensions = await getImageDimensions(result);
+      expect(dimensions.width).toBe(10);
+      expect(dimensions.height).toBe(10);
+    });
+
+    it('should not re-encode a WebP image when the target type matches the source', async () => {
+      const source = createImage(10, 10, 'image/webp');
+      const result = await FileService
+        .scaleImage(source, { maxWidth: 100, maxHeight: 100, targetMimeType: 'image/webp' });
+      expect(result).toBe(source);
+    });
+
+    it('should downscale while keeping the aspect ratio', async () => {
+      const source = createImage(20, 10);
+      const result = await FileService.scaleImage(source, { maxWidth: 10, maxHeight: 10 });
+      const dimensions = await getImageDimensions(result);
+      expect(dimensions.width).toBe(10);
+      expect(dimensions.height).toBe(5);
+    });
+
+    it('should return the original image when uncompressed is set', async () => {
+      const source = createImage(20, 10);
+      const result = await FileService
+        .scaleImage(source, { maxWidth: 10, uncompressed: true, targetMimeType: 'image/webp' });
+      expect(result).toBe(source);
+    });
+  });
+});

--- a/projects/common/services/file.service.ts
+++ b/projects/common/services/file.service.ts
@@ -83,10 +83,13 @@ export class FileService {
 
         let { width, height } = img;
 
-        if (width <= maxWidth && height <= maxHeight) {
+        const needsResize = width > maxWidth || height > maxHeight;
+        const needsConversion = options.targetMimeType !== undefined && options.targetMimeType !== mimeType;
+
+        if (!needsResize && !needsConversion) {
           resolve(base64Image);
         } else {
-          const ratio = Math.min(maxWidth / width, maxHeight / height);
+          const ratio = needsResize ? Math.min(maxWidth / width, maxHeight / height) : 1;
           width *= ratio;
           height *= ratio;
 

--- a/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.html
+++ b/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.html
@@ -5,9 +5,11 @@
       <img [src]="data.base64" class="preview-image">
       <div class="image-info">
         <div>{{ 'imageResizeDialog.originalSize' | translate }}: {{ originalWidth }} x {{ originalHeight }} px ({{ originalSize | bytes }})</div>
-        <div *ngIf="estimatedSize !== originalSize" class="estimated-size">
-          {{ 'imageResizeDialog.newSize' | translate }}: <strong>{{ estimatedSize | bytes }}</strong>
-        </div>
+        @if (estimatedSize !== originalSize) {
+          <div class="estimated-size">
+            {{ 'imageResizeDialog.newSize' | translate }}: <strong>{{ estimatedSize | bytes }}</strong>
+          </div>
+        }
       </div>
     </div>
 
@@ -15,38 +17,40 @@
       {{ 'imageResizeDialog.useOriginalFile' | translate }}
     </mat-checkbox>
 
-    <mat-checkbox *ngIf="!data.base64.includes('image/webp')"
-                  [ngModel]="data.options.targetMimeType === 'image/webp'"
-                  (ngModelChange)="onFormatChange($event)">
-      {{ 'imageResizeDialog.convertToWebP' | translate }}
-    </mat-checkbox>
+    @if (!data.base64.includes('image/webp')) {
+      <mat-checkbox [ngModel]="data.options.targetMimeType === 'image/webp'"
+                    (ngModelChange)="onFormatChange($event)">
+        {{ 'imageResizeDialog.convertToWebP' | translate }}
+      </mat-checkbox>
+    }
 
-    <ng-container *ngIf="!data.options.uncompressed">
+    @if (!data.options.uncompressed) {
       <div class="fx-row-start-center dimensions-row">
         <mat-form-field appearance="fill" style="flex: 1;">
           <mat-label>{{ 'imageResizeDialog.maxWidth' | translate }}</mat-label>
           <input matInput type="number" min="1" [(ngModel)]="data.options.maxWidth" (ngModelChange)="onWidthChange($event)">
         </mat-form-field>
 
-        <button mat-icon-button (click)="keepAspectRatio = !keepAspectRatio" [color]="keepAspectRatio ? 'primary' : ''"
-                [matTooltip]="'imageResizeDialog.keepAspectRatio' | translate">
-          <mat-icon>{{ keepAspectRatio ? 'link' : 'link_off' }}</mat-icon>
-        </button>
+        <mat-icon class="aspect-ratio-lock" color="primary"
+                  [matTooltip]="'imageResizeDialog.aspectRatioLocked' | translate">
+          link
+        </mat-icon>
 
         <mat-form-field appearance="fill" style="flex: 1;">
           <mat-label>{{ 'imageResizeDialog.maxHeight' | translate }}</mat-label>
-          <input matInput type="number" min="1" [(ngModel)]="data.options.maxHeight" (ngModelChange)="onHeightChange($event)"
-                 [placeholder]="'imageResizeDialog.unlimited' | translate">
+          <input matInput type="number" min="1" [(ngModel)]="data.options.maxHeight" (ngModelChange)="onHeightChange($event)">
         </mat-form-field>
       </div>
 
-      <div *ngIf="data.base64 | supportsQuality:data.options.targetMimeType" class="fx-column-start-stretch">
-        <label>{{ 'imageResizeDialog.quality' | translate }} ({{ ((data.options.quality || 0) * 100).toFixed(0) }}%)</label>
-        <mat-slider min="0.1" max="1" step="0.05">
-          <input matSliderThumb [(ngModel)]="data.options.quality" (ngModelChange)="onQualityChange()">
-        </mat-slider>
-      </div>
-    </ng-container>
+      @if (data.base64 | supportsQuality:data.options.targetMimeType) {
+        <div class="fx-column-start-stretch">
+          <label>{{ 'imageResizeDialog.quality' | translate }} ({{ ((data.options.quality || 0) * 100).toFixed(0) }}%)</label>
+          <mat-slider min="0.1" max="1" step="0.05">
+            <input matSliderThumb [(ngModel)]="data.options.quality" (ngModelChange)="onQualityChange()">
+          </mat-slider>
+        </div>
+      }
+    }
   </div>
 </mat-dialog-content>
 <mat-dialog-actions>

--- a/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.scss
+++ b/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.scss
@@ -17,6 +17,10 @@
   align-items: baseline;
 }
 
+.aspect-ratio-lock {
+  align-self: center;
+}
+
 .main-container {
   gap: 20px;
   margin-top: 10px;

--- a/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.spec.ts
+++ b/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.spec.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { ImageResizeDialogData } from 'common/interfaces';
 import { BytesPipe } from '../../pipes/bytes.pipe';
 import { SupportsQualityPipe } from '../../pipes/supports-quality.pipe';
 import { ImageResizeDialogComponent } from './image-resize-dialog.component';
@@ -17,17 +18,18 @@ import { ImageResizeDialogComponent } from './image-resize-dialog.component';
 describe('ImageResizeDialogComponent', () => {
   let component: ImageResizeDialogComponent;
   let fixture: ComponentFixture<ImageResizeDialogComponent>;
-
-  const mockDialogData = {
-    // eslint-disable-next-line max-len
-    base64: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
-    options: {
-      maxWidth: 500,
-      quality: 0.8
-    }
-  };
+  let mockDialogData: ImageResizeDialogData;
 
   beforeEach(async () => {
+    mockDialogData = {
+      // eslint-disable-next-line max-len
+      base64: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      options: {
+        maxWidth: 500,
+        quality: 0.8
+      }
+    };
+
     await TestBed.configureTestingModule({
       declarations: [
         ImageResizeDialogComponent,
@@ -95,5 +97,35 @@ describe('ImageResizeDialogComponent', () => {
       expect(component.originalSize).toBeGreaterThan(0);
       done();
     }, 200);
+  });
+
+  it('should clamp maxWidth to the original width and sync maxHeight on init', done => {
+    setTimeout(() => {
+      expect(component.data.options.maxWidth).toBe(1);
+      expect(component.data.options.maxHeight).toBe(1);
+      done();
+    }, 200);
+  });
+
+  it('should always sync maxHeight to the aspect ratio when the width changes', () => {
+    component.originalWidth = 200;
+    component.originalHeight = 100;
+    component.onWidthChange(100);
+    expect(component.data.options.maxHeight).toBe(50);
+  });
+
+  it('should always sync maxWidth to the aspect ratio when the height changes', () => {
+    component.originalWidth = 200;
+    component.originalHeight = 100;
+    component.onHeightChange(30);
+    expect(component.data.options.maxWidth).toBe(60);
+  });
+
+  it('should not sync dimensions while the input is empty', () => {
+    component.originalWidth = 200;
+    component.originalHeight = 100;
+    component.data.options.maxHeight = 75;
+    component.onWidthChange(null as unknown as number);
+    expect(component.data.options.maxHeight).toBe(75);
   });
 });

--- a/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.ts
+++ b/projects/editor/src/app/components/image-resize-dialog/image-resize-dialog.component.ts
@@ -13,7 +13,6 @@ import { IMAGE_COMPRESSION_QUALITY, IMAGE_MAX_WIDTH } from 'common/config';
 export class ImageResizeDialogComponent implements OnInit {
   originalWidth: number = 0;
   originalHeight: number = 0;
-  keepAspectRatio: boolean = true;
   originalSize: number = 0;
   estimatedSize: number = 0;
 
@@ -34,6 +33,8 @@ export class ImageResizeDialogComponent implements OnInit {
     img.onload = () => {
       this.originalWidth = img.width;
       this.originalHeight = img.height;
+      this.data.options.maxWidth = Math.min(this.data.options.maxWidth || IMAGE_MAX_WIDTH, img.width);
+      this.data.options.maxHeight = Math.round(this.data.options.maxWidth * (img.height / img.width));
       this.updateEstimatedSize();
     };
   }
@@ -44,14 +45,14 @@ export class ImageResizeDialogComponent implements OnInit {
   }
 
   onWidthChange(value: number): void {
-    if (this.keepAspectRatio && this.originalWidth && this.originalHeight) {
+    if (value && this.originalWidth && this.originalHeight) {
       this.data.options.maxHeight = Math.round(value * (this.originalHeight / this.originalWidth));
     }
     this.updateEstimatedSize();
   }
 
   onHeightChange(value: number): void {
-    if (this.keepAspectRatio && this.originalWidth && this.originalHeight) {
+    if (value && this.originalWidth && this.originalHeight) {
       this.data.options.maxWidth = Math.round(value * (this.originalWidth / this.originalHeight));
     }
     this.updateEstimatedSize();

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -426,8 +426,7 @@
     "useOriginalFile": "Originaldatei verwenden (keine Komprimierung)",
     "maxWidth": "Maximale Breite (px)",
     "maxHeight": "Maximale Höhe (px)",
-    "keepAspectRatio": "Seitenverhältnis beibehalten",
-    "unlimited": "Unbegrenzt",
+    "aspectRatioLocked": "Das Seitenverhältnis bleibt immer erhalten",
     "quality": "Qualität",
     "convertToWebP": "In WebP konvertieren (spart Speicherplatz)",
     "newSize": "Voraussichtliche neue Größe"

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -421,7 +421,7 @@
     "corruptElement": "Element-Ressource ist vermutlich fehlerhaft und sollte ausgetauscht werden! \n\n Ursprüngliche Fehlermeldung: {{ errorMsg }}"
   },
   "imageResizeDialog": {
-    "title": "Bildeinstellungen",
+    "title": "Bild komprimieren",
     "originalSize": "Originalgröße",
     "useOriginalFile": "Originaldatei verwenden (keine Komprimierung)",
     "maxWidth": "Maximale Breite (px)",


### PR DESCRIPTION
## Summary

Fixes two bugs in the image import dialog:

### #1086 — "Seitenverhältnis beibehalten" toggle had no function
The unlink toggle suggested that the image could be stretched, but scaling always preserves the aspect ratio (`FileService.scaleImage` uses contain-fit). Instead of implementing stretching, the misleading option is removed entirely:
- Width and height inputs are now **always coupled** — changing one recalculates the other.
- A static link icon with tooltip ("Das Seitenverhältnis bleibt immer erhalten") communicates the fixed coupling.
- On dialog open, the dimension fields are initialized with the **effective output size** (max width clamped to the original width, height derived from the aspect ratio), so it is clear the image is compressed via either width or height.

### #1090 — WebP conversion did not compress at same/larger dimensions
`FileService.scaleImage` returned the original image whenever no downscaling was needed — before evaluating `targetMimeType`/`quality`. Now:
- Re-encoding also happens **without resizing** when the requested target mime type differs from the source.
- Upscaling still never occurs (larger max dimensions keep the original size).
- The estimated new size is displayed accordingly.

## Tests
- New `file.service.spec.ts` covering `scaleImage`: no-op passthrough, WebP conversion without resize, no upscaling, same-type passthrough, aspect-ratio downscale, `uncompressed` bypass.
- Dialog spec extended: init clamping/sync, width↔height coupling, empty-input guard; shared mock dialog data made per-test to avoid cross-test mutation.

## Verification
- `tsc --noEmit` clean (editor app + spec, common spec)
- ESLint clean on all changed files
- Unit tests: common 125/125, editor 56/56 ✅

Closes #1086
Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)