### PR TITLE
Validate variable ids/aliases against Verona pattern (#1043)

### DIFF
--- a/projects/common/models/elements/element.spec.ts
+++ b/projects/common/models/elements/element.spec.ts
@@ -1,0 +1,42 @@
+import { ElementFactory } from 'common/utils/element-factory';
+import { AbstractIDService, UIElementProperties } from 'common/interfaces';
+import { UIElement } from 'common/models/elements/element';
+
+describe('UIElement setProperty alias validation', () => {
+  let element: UIElement;
+
+  const idServiceStub: AbstractIDService = {
+    getAndRegisterNewID: () => 'text_1',
+    register: () => {},
+    unregister: () => {},
+    isAliasAvailable: () => true,
+    changeAlias: () => {}
+  };
+
+  beforeEach(() => {
+    element = ElementFactory.createElement({
+      type: 'text',
+      id: 'text_1',
+      alias: 'text_1'
+    } as unknown as UIElementProperties);
+    element.idService = idServiceStub;
+  });
+
+  it('should accept aliases with letters, digits, underscore and dash', () => {
+    element.setProperty('alias', 'var_1-neu');
+    expect(element.alias).toBe('var_1-neu');
+  });
+
+  it('should reject aliases with umlauts', () => {
+    expect(() => element.setProperty('alias', 'März')).toThrowError(/unerlaubte Zeichen/);
+    expect(() => element.setProperty('alias', 'Lösung1')).toThrowError(/unerlaubte Zeichen/);
+  });
+
+  it('should reject aliases with trailing whitespace', () => {
+    expect(() => element.setProperty('alias', 'weiter ')).toThrowError(/Leerzeichen/);
+  });
+
+  it('should reject aliases longer than 20 characters', () => {
+    expect(() => element.setProperty('alias', 'a'.repeat(21))).toThrowError(/20 Zeichen/);
+  });
+});

--- a/projects/common/models/elements/element.ts
+++ b/projects/common/models/elements/element.ts
@@ -13,6 +13,7 @@ import {
 } from 'common/interfaces';
 import { IDError, InstantiationEror } from 'common/errors';
 import { GLOBAL_DEFAULTS } from 'common/models/elements/element-registry';
+import { VariableAlias } from 'common/utils/variable-alias';
 
 type RevisionAwareIDService = AbstractIDService & { getResetRevision?: () => number };
 
@@ -92,6 +93,9 @@ export abstract class UIElement implements UIElementProperties {
       }
       if ((value as string).includes(' ')) {
         throw new IDError('ID enthält unerlaubtes Leerzeichen');
+      }
+      if (!VariableAlias.isValid(value as string)) {
+        throw new IDError('ID enthält unerlaubte Zeichen (erlaubt: a-z, A-Z, 0-9, _, -)');
       }
       this.idService.unregister(this.alias, false, true);
       this.idService.register(value as string, false, true);

--- a/projects/common/models/elements/input-elements/drop-list.ts
+++ b/projects/common/models/elements/input-elements/drop-list.ts
@@ -16,6 +16,7 @@ import {
 import { IDError, InstantiationEror } from 'common/errors';
 
 import { ELEMENT_DEFAULTS } from 'common/models/elements/element-registry';
+import { VariableAlias } from 'common/utils/variable-alias';
 
 export class DropListElement extends InputElement implements DropListProperties {
   type: UIElementType = 'drop-list';
@@ -98,6 +99,9 @@ export class DropListElement extends InputElement implements DropListProperties 
     if (value.alias !== this.value[valueIndex].alias) {
       if (!this.idService?.isAliasAvailable(value.alias)) {
         throw new IDError('ID ist bereits vergeben');
+      }
+      if (!VariableAlias.isValid(value.alias)) {
+        throw new IDError('ID enthält unerlaubte Zeichen (erlaubt: a-z, A-Z, 0-9, _, -)');
       }
       this.idService?.changeAlias(this.value[valueIndex].alias, value.alias);
     }

--- a/projects/common/utils/variable-alias.spec.ts
+++ b/projects/common/utils/variable-alias.spec.ts
@@ -1,0 +1,29 @@
+import { VariableAlias } from 'common/utils/variable-alias';
+
+describe('VariableAlias', () => {
+  it('should accept names with letters, digits, underscore and dash', () => {
+    expect(VariableAlias.isValid('var1')).toBeTrue();
+    expect(VariableAlias.isValid('drop-list_2')).toBeTrue();
+    expect(VariableAlias.isValid('ABC-def_123')).toBeTrue();
+    expect(VariableAlias.isValid('_')).toBeTrue();
+    expect(VariableAlias.isValid('-')).toBeTrue();
+  });
+
+  it('should reject names with umlauts or other special characters', () => {
+    expect(VariableAlias.isValid('März')).toBeFalse();
+    expect(VariableAlias.isValid('Häufigkeiten')).toBeFalse();
+    expect(VariableAlias.isValid('Lösung1')).toBeFalse();
+    expect(VariableAlias.isValid('a.b')).toBeFalse();
+    expect(VariableAlias.isValid('a+b')).toBeFalse();
+  });
+
+  it('should reject names with leading or trailing whitespace', () => {
+    expect(VariableAlias.isValid('weiter ')).toBeFalse();
+    expect(VariableAlias.isValid(' weiter')).toBeFalse();
+    expect(VariableAlias.isValid('wei ter')).toBeFalse();
+  });
+
+  it('should reject empty names', () => {
+    expect(VariableAlias.isValid('')).toBeFalse();
+  });
+});

--- a/projects/common/utils/variable-alias.ts
+++ b/projects/common/utils/variable-alias.ts
@@ -1,0 +1,8 @@
+export abstract class VariableAlias {
+  /* Verona-compliant pattern for VariableInfo ids and aliases (#1043) */
+  static readonly PATTERN: RegExp = /^[0-9a-zA-Z_-]+$/;
+
+  static isValid(alias: string): boolean {
+    return VariableAlias.PATTERN.test(alias);
+  }
+}

--- a/projects/editor/src/app/app.component.spec.ts
+++ b/projects/editor/src/app/app.component.spec.ts
@@ -15,7 +15,7 @@ describe('AppComponent startCommand loading', () => {
   let startCommand$: Subject<StartCommand>;
   let unitService: UnitService;
   let veronaApiServiceMock: Pick<VeronaAPIService, 'startCommand' | 'sendReady' | 'sendChanged'>;
-  let translateServiceMock: Pick<TranslateService, 'addLangs' | 'setDefaultLang'>;
+  let translateServiceMock: Pick<TranslateService, 'addLangs' | 'setDefaultLang' | 'instant'>;
   const expectJasmine = globalThis.expect as unknown as {
     (actual: unknown): jasmine.Matchers<unknown>;
     (actual: () => unknown): jasmine.FunctionMatchers<() => unknown>;
@@ -28,7 +28,8 @@ describe('AppComponent startCommand loading', () => {
     const idService = new IDService();
     const messageServiceSpy = jasmine.createSpyObj<MessageService>('MessageService', [
       'showFixedReferencePanel',
-      'showReferencePanel'
+      'showReferencePanel',
+      'showPrompt'
     ]);
     const dialogServiceSpy = jasmine.createSpyObj<DialogService>('DialogService', [
       'showUnitDefErrorDialog',
@@ -41,18 +42,20 @@ describe('AppComponent startCommand loading', () => {
       sendChanged: jasmine.createSpy('sendChanged')
     };
 
+    translateServiceMock = {
+      addLangs: jasmine.createSpy('addLangs'),
+      setDefaultLang: jasmine.createSpy('setDefaultLang'),
+      instant: jasmine.createSpy('instant').and.callFake(key => key)
+    };
+
     unitService = new UnitService(
       selectionService,
       veronaApiServiceMock as VeronaAPIService,
       messageServiceSpy,
       dialogServiceSpy,
-      idService
+      idService,
+      translateServiceMock as TranslateService
     );
-
-    translateServiceMock = {
-      addLangs: jasmine.createSpy('addLangs'),
-      setDefaultLang: jasmine.createSpy('setDefaultLang')
-    };
   });
 
   it('loads a single non-likert startCommand', fakeAsync(() => {

--- a/projects/editor/src/app/components/dialogs/drop-list-option-edit-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/drop-list-option-edit-dialog.component.ts
@@ -14,7 +14,9 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
         </aspect-rich-text-editor>
         <mat-form-field>
           <mat-label>{{'id' | translate }}</mat-label>
-          <input matInput type="text" [(ngModel)]="newLabel.alias">
+          <input matInput type="text" [(ngModel)]="newLabel.alias" #aliasModel="ngModel"
+                 required pattern="[0-9a-zA-Z_-]+">
+          <mat-error>{{'idContainsInvalidCharacters' | translate }}</mat-error>
         </mat-form-field>
 
         <div class="media-panels">
@@ -56,7 +58,9 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
 
       </mat-dialog-content>
       <mat-dialog-actions>
-        <button mat-button [mat-dialog-close]="newLabel">{{'save' | translate }}</button>
+        <button mat-button [mat-dialog-close]="newLabel" [disabled]="aliasModel.invalid">
+          {{'save' | translate }}
+        </button>
         <button mat-button mat-dialog-close>{{'cancel' | translate }}</button>
       </mat-dialog-actions>
     </div>

--- a/projects/editor/src/app/components/dialogs/likert-row-edit-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/likert-row-edit-dialog.component.ts
@@ -14,7 +14,9 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
 
         <mat-form-field [style.margin-top.px]="15">
           <mat-label>{{'id' | translate }}</mat-label>
-          <input matInput type="text" [(ngModel)]="newLikertRow.alias">
+          <input matInput type="text" [(ngModel)]="newLikertRow.alias" #aliasModel="ngModel"
+                 required pattern="[0-9a-zA-Z_-]+">
+          <mat-error>{{'idContainsInvalidCharacters' | translate }}</mat-error>
         </mat-form-field>
 
         <mat-checkbox [(ngModel)]="newLikertRow.readOnly">
@@ -68,7 +70,7 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
     </mat-dialog-content>
 
     <mat-dialog-actions>
-      <button mat-button [mat-dialog-close]="newLikertRow">
+      <button mat-button [mat-dialog-close]="newLikertRow" [disabled]="aliasModel.invalid">
         {{'save' | translate }}
       </button>
       <button mat-button mat-dialog-close>{{'cancel' | translate }}</button>

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/geometry-props.component.ts
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/geometry-props.component.ts
@@ -2,7 +2,7 @@ import {
   Component, ComponentRef, EventEmitter, Input, OnDestroy, OnInit, Output
 } from '@angular/core';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   AsyncPipe, NgForOf, NgIf
 } from '@angular/common';
@@ -25,7 +25,9 @@ import { takeUntil } from 'rxjs/operators';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import { DialogService } from 'editor/src/app/services/dialog.service';
 import { UnitService } from 'editor/src/app/services/unit.service';
+import { MessageService } from 'editor/src/app/services/message.service';
 import { GeometryVariable } from 'common/interfaces';
+import { VariableAlias } from 'common/utils/variable-alias';
 
 @Component({
   selector: 'aspect-geometry-props',
@@ -145,7 +147,9 @@ export class GeometryPropsComponent implements OnInit, OnDestroy {
 
   constructor(public unitService: UnitService,
               public selectionService: SelectionService,
-              public dialogService: DialogService) { }
+              public dialogService: DialogService,
+              private messageService: MessageService,
+              private translateService: TranslateService) { }
 
   ngOnInit(): void {
     this.initGeometryListener();
@@ -154,6 +158,10 @@ export class GeometryPropsComponent implements OnInit, OnDestroy {
   addTrackedExpectedVariable(event: MatChipInputEvent): void {
     const id = (event.value || '').trim();
     if (!id) return;
+    if (!VariableAlias.isValid(id)) {
+      this.messageService.showError(this.translateService.instant('idContainsInvalidCharacters'));
+      return;
+    }
     const variables = [...(this.combinedProperties.trackedExpectedVariables as GeometryVariable[])];
     if (variables.some(v => v.id === id)) return;
 

--- a/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.html
+++ b/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.html
@@ -4,6 +4,9 @@
     <input matInput #idInput [class.error]="error"
            [ngModel]="stateVariable.alias"
            (input)="checkId(idInput.value)">
+    @if (error) {
+      <mat-hint class="error-hint">{{ errorMessage | translate }}</mat-hint>
+    }
   </mat-form-field>
 
   <mat-form-field>

--- a/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.scss
+++ b/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.scss
@@ -1,3 +1,7 @@
 .error {
   color: #f44336 !important;
 }
+
+.error-hint {
+  color: #f44336;
+}

--- a/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.spec.ts
+++ b/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.spec.ts
@@ -57,6 +57,26 @@ describe('StateVariableEditorComponent', () => {
     mockIDService.isAliasAvailable.and.returnValue(false);
     component.checkId('taken_v1');
     expect(component.error).toBeTrue();
+    expect(component.errorMessage).toBe('idTaken');
     expect(mockIDService.register).not.toHaveBeenCalled();
+  });
+
+  it('should set error if alias contains invalid characters', () => {
+    ['März', 'Lösung1', 'weiter ', ' weiter', 'a.b'].forEach(alias => {
+      component.checkId(alias);
+      expect(component.error).withContext(alias).toBeTrue();
+      expect(component.errorMessage).withContext(alias).toBe('idContainsInvalidCharacters');
+    });
+    expect(mockIDService.register).not.toHaveBeenCalled();
+    expect(component.stateVariable.alias).toBe('v1');
+  });
+
+  it('should clear error when alias becomes valid again', () => {
+    component.checkId('März');
+    expect(component.error).toBeTrue();
+    component.checkId('Maerz');
+    expect(component.error).toBeFalse();
+    expect(component.errorMessage).toBe('');
+    expect(component.stateVariable.alias).toBe('Maerz');
   });
 });

--- a/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.ts
+++ b/projects/editor/src/app/components/state-variable-editor/state-variable-editor.component.ts
@@ -2,6 +2,7 @@ import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
 import { StateVariable } from 'common/models/state-variable';
+import { VariableAlias } from 'common/utils/variable-alias';
 import { IDService } from 'editor/src/app/services/id.service';
 
 @Component({
@@ -12,6 +13,7 @@ import { IDService } from 'editor/src/app/services/id.service';
 })
 export class StateVariableEditorComponent {
   error: boolean = false;
+  errorMessage: string = '';
   @Input() stateVariable!: StateVariable;
   @Output() stateVariableChange = new EventEmitter<StateVariable>();
 
@@ -19,8 +21,15 @@ export class StateVariableEditorComponent {
 
   checkId(alias: string): void {
     if (alias !== this.stateVariable.alias) {
-      this.error = !this.idService.isAliasAvailable(alias);
-      if (!this.error) {
+      if (!VariableAlias.isValid(alias)) {
+        this.error = true;
+        this.errorMessage = 'idContainsInvalidCharacters';
+      } else if (!this.idService.isAliasAvailable(alias)) {
+        this.error = true;
+        this.errorMessage = 'idTaken';
+      } else {
+        this.error = false;
+        this.errorMessage = '';
         this.idService.unregister(this.stateVariable.alias, false, true);
         this.idService.register(alias, false, true);
         this.stateVariable.alias = alias;
@@ -28,6 +37,7 @@ export class StateVariableEditorComponent {
       }
     } else {
       this.error = false;
+      this.errorMessage = '';
     }
   }
 }

--- a/projects/editor/src/app/services/unit.service.spec.ts
+++ b/projects/editor/src/app/services/unit.service.spec.ts
@@ -2,6 +2,8 @@ import { VersionManager } from 'common/services/version-manager';
 import { UnitProperties } from 'common/models/unit';
 import { StateVariable } from 'common/models/state-variable';
 import { MessageService } from 'editor/src/app/services/message.service';
+import { TranslateService } from '@ngx-translate/core';
+import { VariableInfo } from '@iqb/responses';
 import { DialogService } from './dialog.service';
 import { SelectionService } from './selection.service';
 import { IDService } from './id.service';
@@ -11,15 +13,20 @@ import { UnitService } from './unit.service';
 describe('UnitService - rapid load handling', () => {
   let service: UnitService;
   let dialogServiceSpy: jasmine.SpyObj<DialogService>;
+  let veronaApiServiceSpy: jasmine.SpyObj<VeronaAPIService>;
+  let messageServiceSpy: jasmine.SpyObj<MessageService>;
 
   beforeEach(() => {
     const selectionService = new SelectionService();
     const idService = new IDService();
-    const veronaApiServiceSpy = jasmine.createSpyObj<VeronaAPIService>('VeronaAPIService', ['sendChanged']);
-    const messageServiceSpy = jasmine.createSpyObj<MessageService>('MessageService', [
+    veronaApiServiceSpy = jasmine.createSpyObj<VeronaAPIService>('VeronaAPIService', ['sendChanged']);
+    messageServiceSpy = jasmine.createSpyObj<MessageService>('MessageService', [
       'showFixedReferencePanel',
-      'showReferencePanel'
+      'showReferencePanel',
+      'showPrompt'
     ]);
+    const translateServiceSpy = jasmine.createSpyObj<TranslateService>('TranslateService', ['instant']);
+    translateServiceSpy.instant.and.callFake((key: string | string[]) => key as string);
 
     dialogServiceSpy = jasmine.createSpyObj<DialogService>('DialogService', [
       'showUnitDefErrorDialog',
@@ -31,7 +38,8 @@ describe('UnitService - rapid load handling', () => {
       veronaApiServiceSpy,
       messageServiceSpy,
       dialogServiceSpy,
-      idService
+      idService,
+      translateServiceSpy
     );
   });
 
@@ -53,6 +61,55 @@ describe('UnitService - rapid load handling', () => {
 
     expect(service.unit.stateVariables[0].id).toBe('stable-unit');
     expect(dialogServiceSpy.showUnitDefErrorDialog).not.toHaveBeenCalled();
+  });
+});
+
+describe('UnitService - variable info validation (#1043)', () => {
+  let service: UnitService;
+  let veronaApiServiceSpy: jasmine.SpyObj<VeronaAPIService>;
+  let messageServiceSpy: jasmine.SpyObj<MessageService>;
+
+  beforeEach(() => {
+    veronaApiServiceSpy = jasmine.createSpyObj<VeronaAPIService>('VeronaAPIService', ['sendChanged']);
+    messageServiceSpy = jasmine.createSpyObj<MessageService>('MessageService', [
+      'showFixedReferencePanel',
+      'showReferencePanel',
+      'showPrompt'
+    ]);
+    const translateServiceSpy = jasmine.createSpyObj<TranslateService>('TranslateService', ['instant']);
+    translateServiceSpy.instant.and.callFake((key: string | string[]) => key as string);
+
+    service = new UnitService(
+      new SelectionService(),
+      veronaApiServiceSpy,
+      messageServiceSpy,
+      jasmine.createSpyObj<DialogService>('DialogService', ['showUnitDefErrorDialog', 'showDeleteConfirmDialog']),
+      new IDService(),
+      translateServiceSpy
+    );
+  });
+
+  it('does not report variable infos with invalid aliases to the host', () => {
+    service.loadUnitDefinition(JSON.stringify(createUnitBlueprint('März')));
+    service.updateUnitDefinition();
+
+    const reportedVariableInfos = veronaApiServiceSpy.sendChanged.calls.mostRecent().args[2] as VariableInfo[];
+    expect(reportedVariableInfos.length).toBe(0);
+  });
+
+  it('notifies the user when a loaded unit contains invalid aliases', () => {
+    service.loadUnitDefinition(JSON.stringify(createUnitBlueprint('weiter ')));
+    expect(messageServiceSpy.showPrompt).toHaveBeenCalledWith('invalidVariableAliases');
+  });
+
+  it('keeps reporting valid variable infos and shows no prompt', () => {
+    service.loadUnitDefinition(JSON.stringify(createUnitBlueprint('valid_var-1')));
+    service.updateUnitDefinition();
+
+    const reportedVariableInfos = veronaApiServiceSpy.sendChanged.calls.mostRecent().args[2] as VariableInfo[];
+    expect(reportedVariableInfos.length).toBe(1);
+    expect(reportedVariableInfos[0].alias).toBe('valid_var-1');
+    expect(messageServiceSpy.showPrompt).not.toHaveBeenCalled();
   });
 });
 

--- a/projects/editor/src/app/services/unit.service.ts
+++ b/projects/editor/src/app/services/unit.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { VariableInfo } from '@iqb/responses';
 import { FileService } from 'common/services/file.service';
 import { MessageService } from 'editor/src/app/services/message.service';
 import { Unit, UnitProperties } from 'common/models/unit';
@@ -8,6 +10,7 @@ import { StateVariable } from 'common/models/state-variable';
 import { VersionManager } from 'common/services/version-manager';
 import { Section } from 'common/models/section';
 import { SectionCounter } from 'common/utils/section-counter';
+import { VariableAlias } from 'common/utils/variable-alias';
 import { ReferenceList, ReferenceManager } from 'editor/src/app/services/reference-manager';
 import { MigrationManager } from 'common/services/migration-manager';
 import { EditorPage, EditorUnit } from 'editor/src/app/models/editor-unit';
@@ -36,7 +39,8 @@ export class UnitService {
               private veronaApiService: VeronaAPIService,
               private messageService: MessageService,
               private dialogService: DialogService,
-              private idService: IDService) {
+              private idService: IDService,
+              private translateService: TranslateService) {
     this.unit = new EditorUnit(undefined, this.idService);
     this.referenceManager = new ReferenceManager(this.unit);
   }
@@ -92,13 +96,37 @@ export class UnitService {
       this.updateUnitDefinition();
     }
     this.updateSectionCounter();
+    this.checkForInvalidVariableInfos();
+  }
+
+  /* Invalid ids/aliases can come in via imported unit definitions. They are not reported
+     to the host (see getValidVariableInfos), therefore the user gets notified. (#1043) */
+  private checkForInvalidVariableInfos(): void {
+    const invalidVariableInfos = this.unit.getVariableInfos()
+      .filter(variableInfo => !UnitService.isReportableVariableInfo(variableInfo));
+    if (invalidVariableInfos.length > 0) {
+      this.messageService.showPrompt(
+        this.translateService.instant(
+          'invalidVariableAliases',
+          { aliases: invalidVariableInfos.map(v => v.alias ?? v.id).join(', ') }));
+    }
   }
 
   updateUnitDefinition(): void {
     this.veronaApiService.sendChanged(
       UnitService.createUnitDefinition(this.unit),
       `${this.unit.type}@${this.unit.version}`,
-      this.unit.getVariableInfos());
+      this.getValidVariableInfos());
+  }
+
+  private getValidVariableInfos(): VariableInfo[] {
+    return this.unit.getVariableInfos()
+      .filter(variableInfo => UnitService.isReportableVariableInfo(variableInfo));
+  }
+
+  private static isReportableVariableInfo(variableInfo: VariableInfo): boolean {
+    return VariableAlias.isValid(variableInfo.id) &&
+      (variableInfo.alias === undefined || VariableAlias.isValid(variableInfo.alias));
   }
 
   private static createUnitDefinition(unit: Unit): string {

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -16,6 +16,8 @@
   "top": "oben",
   "bottom": "unten",
   "idTaken": "ID ist bereits vergeben",
+  "idContainsInvalidCharacters": "ID enthält unerlaubte Zeichen (erlaubt: a-z, A-Z, 0-9, _, -)",
+  "invalidVariableAliases": "Folgende Variablen-IDs entsprechen nicht dem erlaubten Muster (a-z, A-Z, 0-9, _, -) und werden nicht an den Host gemeldet: {{aliases}}",
   "inputInvalid": "Eingabe ungültig",
   "outdatedUnit": "Unit Definition aktualisiert",
   "save": "Speichern",


### PR DESCRIPTION
Closes #1043

## Änderungen

- **Zentrale Validierung**: Neue Utility `VariableAlias` in `projects/common/utils/variable-alias.ts` mit dem erlaubten Muster `^[0-9a-zA-Z_-]+$`.
- **Element-Aliase** (inkl. Likert-Rows): `UIElement.setProperty()` wirft bei unerlaubten Zeichen jetzt einen `IDError` (zusätzlich zu Dublette/Länge/Leerzeichen).
- **Zustandsvariablen**: `StateVariableEditorComponent` prüft das Muster vor der Verfügbarkeit und zeigt eine konkrete Fehlermeldung unter dem Eingabefeld.
- **Drop-List-Optionen & Likert-Rows**: ID-Felder in den Dialogen haben `required`- und `pattern`-Validatoren mit `mat-error`; der Speichern-Button ist bei ungültiger ID deaktiviert. Backstop zusätzlich in `DropListElement.updateValueObject()`.
- **Geometry**: Manuell eingegebene tracked expected variables werden gegen das Muster geprüft; bei Verstoß erscheint eine Fehlermeldung statt der Übernahme.
- **Importierte UnitDefinitions**: Vor jeder `voeDefinitionChangedNotification` werden `VariableInfo`s mit ungültiger `id`/`alias` herausgefiltert. Beim Laden einer Unit mit ungültigen Aliassen wird ein Hinweis mit den betroffenen Namen angezeigt; die Bestandsdaten selbst bleiben unangetastet, sodass Autor:innen die Aliase selbst korrigieren können.

## Tests

- Neue Specs: `variable-alias.spec.ts`, `element.spec.ts` (Alias-Validierung in `setProperty`)
- Erweitert: `state-variable-editor.component.spec.ts`, `unit.service.spec.ts` (Filterung + Hinweis)
- Testläufe: common 133 ✓, editor 61 ✓, player 213 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)