### PR TITLE
Widget-Buttons: Innenabstand statt Margin, damit der Schatten vollständig sichtbar ist (#1077)

### DIFF
--- a/projects/common/components/widget-molecule-editor/widget-molecule-editor.component.html
+++ b/projects/common/components/widget-molecule-editor/widget-molecule-editor.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="widget-container">
   <button mat-mini-fab
           type='button'
           [matTooltip]="'openWidget' | translate: { widget: ('moleculeEditor' | translate) }"

--- a/projects/common/components/widget-molecule-editor/widget-molecule-editor.component.scss
+++ b/projects/common/components/widget-molecule-editor/widget-molecule-editor.component.scss
@@ -1,0 +1,5 @@
+// The padding keeps the button's shadow within the element bounds,
+// so neighboring elements cannot cover it.
+.widget-container {
+  padding: 10px;
+}

--- a/projects/common/components/widget-periodic-table/widget-periodic-table.component.html
+++ b/projects/common/components/widget-periodic-table/widget-periodic-table.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="widget-container">
   <button mat-mini-fab
           type='button'
           [matTooltip]="'openWidget' | translate: { widget: ('periodicTable' | translate) }"

--- a/projects/common/components/widget-periodic-table/widget-periodic-table.component.scss
+++ b/projects/common/components/widget-periodic-table/widget-periodic-table.component.scss
@@ -1,8 +1,14 @@
+// The padding keeps the button's shadow within the element bounds,
+// so neighboring elements cannot cover it.
+.widget-container {
+  padding: 10px;
+}
+
 .elements-container {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  padding: 10px;
+  padding: 10px 0 0;
 }
 
 .element-square {


### PR DESCRIPTION
Closes #1077

## Problem
Beim Einfügen mehrerer Widgets überdecken sich die Elemente zum Teil: Die Fab-Buttons (Periodensystem, Molekül-Editor) sitzen direkt an der Elementgrenze, sodass ihr Material-Schatten vom jeweils nächsten Element abgeschnitten bzw. überdeckt wird.

## Lösung
Statt eines voreingestellten Abstands (5px `marginBottom`) im Elementmodel reservieren die Widget-Komponenten selbst genug Platz um den Button (`padding: 10px` auf dem Container), sodass der Schatten vollständig innerhalb der Elementgrenzen dargestellt wird. Damit ist das Verhalten unabhängig vom Layout (statisch/dynamisch) und von Margin-Einstellungen der Nutzer.

- Bei der Standardgröße (40px-Button + 2×10px Padding = 60px) entspricht die Inhaltshöhe exakt der Standard-Elementhöhe.
- Der Innenabstand der Zustandsanzeige des Periodensystems wurde angepasst, damit sich das Padding nicht verdoppelt.

Verifiziert per Cypress gegen den Editor-Dev-Server: zwei gestapelte Widgets haben jetzt 20px Abstand zwischen den Buttons, die Schatten werden vollständig gerendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)