### PR TITLE
Fix scrolling in image fullscreen dialog (#1074)

### DIFF
--- a/e2e/tests/e2e/image-fullscreen.spec.cy.ts
+++ b/e2e/tests/e2e/image-fullscreen.spec.cy.ts
@@ -1,0 +1,57 @@
+import {
+  addElement, setCheckbox, uploadFile, clickButtonDialog
+} from '../util';
+
+describe('Image element with fullscreen view', { testIsolation: false }, () => {
+  context('editor', () => {
+    before('opens an editor', () => {
+      cy.openEditor();
+    });
+
+    it('creates an image element with fullscreen view allowed', () => {
+      cy.stubFileInput();
+      addElement('Bild', 'Medium');
+      uploadFile('446878.jpeg');
+      clickButtonDialog('Speichern');
+      setCheckbox('Vollbildansicht erlauben');
+    });
+
+    after('saves unit definition', () => {
+      cy.saveUnit('e2e/downloads/image-fullscreen.json');
+    });
+  });
+
+  // Small viewport so the image is larger than the fullscreen dialog and must scroll
+  context('player', { viewportWidth: 500, viewportHeight: 300 }, () => {
+    before('opens player and loads unit', () => {
+      cy.openPlayer();
+      cy.loadUnit('../downloads/image-fullscreen.json');
+    });
+
+    it('opens the fullscreen dialog on image click', () => {
+      cy.get('aspect-image img').click();
+      cy.get('.image-fullscreen-dialog mat-dialog-content img').should('be.visible');
+    });
+
+    it('keeps the dialog within the viewport', () => {
+      cy.get('.image-fullscreen-dialog mat-dialog-content').should($content => {
+        expect($content[0].getBoundingClientRect().bottom).to.be.at.most(Cypress.config('viewportHeight'));
+      });
+    });
+
+    it('allows scrolling the image inside the fullscreen dialog (#1074)', () => {
+      cy.get('.image-fullscreen-dialog mat-dialog-content').should($content => {
+        expect($content[0].scrollHeight).to.be.greaterThan($content[0].clientHeight);
+      });
+      cy.get('.image-fullscreen-dialog mat-dialog-content').scrollTo('bottom');
+      cy.get('.image-fullscreen-dialog mat-dialog-content').should($content => {
+        expect($content[0].scrollTop).to.be.greaterThan(0);
+      });
+    });
+
+    it('closes the fullscreen dialog on click', () => {
+      cy.get('.image-fullscreen-dialog mat-dialog-content').click();
+      cy.get('.image-fullscreen-dialog').should('not.exist');
+    });
+  });
+});

--- a/projects/common/assets/common-styles.css
+++ b/projects/common/assets/common-styles.css
@@ -115,9 +115,13 @@ blockquote p {
   z-index: 100 !important;
 }
 
+/* '!important' is needed because Material injects its structural styles ('.cdk-overlay-pane'
+   with 'max-width'/'max-height: 100%') at runtime after this stylesheet. Without a definite
+   (viewport-relative) max-height on the pane, the inherited percentage max-heights of the
+   dialog containers cannot resolve and the dialog grows beyond the viewport without scrolling. */
 .image-fullscreen-dialog {
   max-width: 95vw !important;
-  max-height: 95vh;
+  max-height: 95vh !important;
 }
 
 .image-fullscreen-dialog mat-dialog-content {


### PR DESCRIPTION
Closes #1074

## Problem
Seit dem Update auf Angular/Material 19+ werden die strukturellen Overlay-Styles (`.cdk-overlay-pane` mit `max-height: 100%`) zur Laufzeit **nach** der `common-styles.css` in den `<head>` injiziert und überschreiben dadurch das `max-height: 95vh` des Vollbild-Dialogs (gleiche Spezifität, spätere Quellreihenfolge). Die von den Dialog-Containern per `max-height: inherit` geerbten Prozentwerte können sich gegen den auto-hohen Overlay-Pane nicht auflösen — der Dialog wächst über den Viewport hinaus und große Bilder lassen sich nicht mehr scrollen.

## Lösung
`max-height: 95vh !important` auf `.image-fullscreen-dialog` (analog zum bereits vorhandenen `max-width: 95vw !important`). Damit ist die Pane-Höhe wieder definit, die Container werden korrekt begrenzt und `mat-dialog-content` scrollt wie zuvor.

## Tests
Neuer E2E-Test `image-fullscreen.spec.cy.ts`: erstellt im Editor ein Bild mit „Vollbildansicht erlauben", öffnet es im Player bei kleinem Viewport und prüft, dass der Dialog im Viewport bleibt und der Inhalt scrollbar ist. Ohne den Fix schlagen beide Prüfungen fehl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)