### PR TITLE
Fix focus ring gaps on table text inputs in Firefox (#1091)

### DIFF
--- a/e2e/tests/e2e/table.spec.cy.ts
+++ b/e2e/tests/e2e/table.spec.cy.ts
@@ -140,14 +140,22 @@ describe('Table element', { testIsolation: false }, () => {
         });
 
         it('shows an inset focus ring on the focused table text-field', () => {
-            // The ring must lie inside the cell, otherwise neighboring cells cover it (#1069)
+            // The ring must lie inside the cell, otherwise neighboring cells cover it (#1069).
+            // It is drawn by coloring the always-present transparent border, because an
+            // inset outline leaves 1px gaps to the table lines in Firefox (#1091).
+            cy.get('aspect-table').eq(1)
+                .find('aspect-text-field input')
+                .blur({ force: true })
+                .should('have.css', 'border-style', 'solid')
+                .and('have.css', 'border-width', '2px')
+                .and('have.css', 'border-color', 'rgba(0, 0, 0, 0)');
+
             cy.get('aspect-table').eq(1)
                 .find('aspect-text-field input')
                 .focus()
-                .should('have.css', 'outline-style', 'solid')
-                .and('have.css', 'outline-offset', '-2px')
+                .should('have.css', 'outline-style', 'none')
                 // indigo-pink theme primary, like the focused mat-form-field
-                .and('have.css', 'outline-color', 'rgb(63, 81, 181)');
+                .and('have.css', 'border-color', 'rgb(63, 81, 181)');
         });
 
         it('second table contains a checkbox and allows checking', () => {

--- a/projects/common/components/input-elements/text-area.component.ts
+++ b/projects/common/components/input-elements/text-area.component.ts
@@ -102,15 +102,18 @@ import { TextInputComponent } from 'common/directives/text-input-component.direc
       min-height: calc(100% - 1px);
       width: 100%;
       box-sizing: border-box;
-      border: none;
-      padding: 0 10px;
+      border: 2px solid transparent;
+      padding: 0 8px;
       font-family: inherit;
     }
     /* The textarea fills the whole table cell, so the native focus ring would be
-       painted into the neighboring cells and get covered by them. Draw it inset instead. */
+       painted into the neighboring cells and get covered by them (#1069). An inset
+       outline is rounded away from fractional cell edges by Firefox, leaving a 1px
+       gap to the table lines (#1091). The border shares the geometry of the textarea's
+       background, so coloring the always-present transparent border cannot leave gaps. */
     .table-child:focus-visible {
-      outline: 2px solid var(--outline-color-primary);
-      outline-offset: -2px;
+      border-color: var(--outline-color-primary);
+      outline: none;
     }
     .errors {
       border: 2px solid #f44336 !important;

--- a/projects/common/components/input-elements/text-field.component.ts
+++ b/projects/common/components/input-elements/text-field.component.ts
@@ -104,15 +104,18 @@ import { TextInputComponent } from 'common/directives/text-input-component.direc
       width: 100%;
       height: 100%;
       box-sizing: border-box;
-      border: none;
-      padding: 0 10px;
+      border: 2px solid transparent;
+      padding: 0 8px;
       font-family: inherit;
     }
     /* The input fills the whole table cell, so the native focus ring would be
-       painted into the neighboring cells and get covered by them. Draw it inset instead. */
+       painted into the neighboring cells and get covered by them (#1069). An inset
+       outline is rounded away from fractional cell edges by Firefox, leaving a 1px
+       gap to the table lines (#1091). The border shares the geometry of the input's
+       background, so coloring the always-present transparent border cannot leave gaps. */
     .table-child:focus-visible {
-      outline: 2px solid var(--outline-color-primary);
-      outline-offset: -2px;
+      border-color: var(--outline-color-primary);
+      outline: none;
     }
     .errors {
       border: 2px solid #f44336 !important;


### PR DESCRIPTION
Closes #1091

## Problem
Der mit #1069 eingeführte Fokusrahmen (`outline` mit `outline-offset: -2px`) wird von Firefox auf einem eigenen Rasterisierungspfad gezeichnet: Bei krummen Zellhöhen (fr-basierte Tabellenzeilen, z. B. 200px / 3 Zeilen) rundet Firefox das Outline-Rechteck nach innen. Ergebnis: je nach Zeile ein sichtbarer 1px-Abstand zwischen Fokusrahmen und Tabellenlinien — alternierend, weil die Zellgrenzen abwechselnd auf ganzen und gebrochenen Pixelpositionen liegen. Der Hintergrund des Eingabefelds füllt die Zelle dagegen korrekt aus (im Ticket-Screenshot reicht das Beige bis an die Linien).

## Lösung
Die Tabellen-Eingabefelder (`text-field`, `text-area` im `tableMode`) erhalten dauerhaft einen 2px breiten transparenten Rand, der bei Fokus eingefärbt wird (`border-color: var(--outline-color-primary)`). Rand und Hintergrund teilen sich dieselbe Box-Geometrie — zwischen Fokusrahmen und Tabellenlinie kann konstruktionsbedingt keine Lücke mehr entstehen, egal wie der Browser gebrochene Pixelpositionen rundet. Das Padding wurde um die Randbreite reduziert (10px → 8px), damit die Textposition unverändert bleibt.

Verifiziert im lokal laufenden Player mit Firefox (Playwright) per Pixel-Analyse bei Device-Pixel-Ratio 1, 1.25 und 1.5: Der Ring liegt in allen Zeilen unmittelbar an den Tabellenlinien.

## Tests
- E2E-Test in `table.spec.cy.ts` an die neue Rahmen-Implementierung angepasst (prüft transparenten 2px-Rand ohne Fokus, blauen Rand + `outline: none` mit Fokus); Spec läuft komplett grün (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)