### PR TITLE
Add heading element to sort list section in Drag & Drop wizard (#1046)

### DIFF
--- a/projects/editor/src/app/section-templates/builders/droplist-builders.spec.ts
+++ b/projects/editor/src/app/section-templates/builders/droplist-builders.spec.ts
@@ -1,0 +1,50 @@
+import { IDService } from 'editor/src/app/services/id.service';
+import { SortTemplateOptions } from 'editor/src/app/section-templates/droplist-interfaces';
+import { TextElement } from 'common/models/elements/text/text';
+import { DropListElement } from 'common/models/elements/input-elements/drop-list';
+import { createSortlistSection } from './droplist-builders';
+
+describe('droplist-builders', () => {
+  describe('createSortlistSection', () => {
+    let idService: IDService;
+
+    const sortOptions: SortTemplateOptions = {
+      text1: '<p>Sortiere die Elemente.</p>',
+      headingSourceList: '<p>Meine Überschrift</p>',
+      options: ['Option A', 'Option B'],
+      optionWidth: 'medium',
+      numbering: true
+    };
+
+    beforeEach(() => {
+      idService = new IDService();
+    });
+
+    it('should create a text element for the heading of the sort list', () => {
+      const section = createSortlistSection(sortOptions, idService);
+      const textElements = section.getAllElements('text') as TextElement[];
+      const headingElement = textElements.find(el => el.text === sortOptions.headingSourceList);
+      expect(headingElement).toBeDefined();
+      expect(headingElement?.styling.bold).toBeTrue();
+    });
+
+    it('should place the heading between the intro text and the sort list', () => {
+      const section = createSortlistSection(sortOptions, idService);
+      const introElement = section.elements
+        .find(el => (el as TextElement).text === sortOptions.text1) as TextElement;
+      const headingElement = section.elements
+        .find(el => (el as TextElement).text === sortOptions.headingSourceList) as TextElement;
+      const dropList = section.getAllElements('drop-list')[0] as DropListElement;
+      expect(headingElement.position.gridRow).toBeGreaterThan(introElement.position.gridRow as number);
+      expect(dropList.position.gridRow).toBeGreaterThan(headingElement.position.gridRow as number);
+    });
+
+    it('should create the sort list with the given options', () => {
+      const section = createSortlistSection(sortOptions, idService);
+      const dropList = section.getAllElements('drop-list')[0] as DropListElement;
+      expect(dropList.isSortList).toBeTrue();
+      expect(dropList.showNumbering).toBeTrue();
+      expect(dropList.value.length).toBe(2);
+    });
+  });
+});

--- a/projects/editor/src/app/section-templates/builders/droplist-builders.ts
+++ b/projects/editor/src/app/section-templates/builders/droplist-builders.ts
@@ -203,8 +203,13 @@ export function createSortlistSection(options: SortTemplateOptions, idService: I
       { text: options.text1 },
       idService),
     TemplateService.createElement(
+      'text',
+      { gridRow: 2, gridColumn: 1, marginBottom: { value: 20, unit: 'px' } },
+      { text: options.headingSourceList, styling: { bold: true } },
+      idService),
+    TemplateService.createElement(
       'drop-list',
-      { gridRow: 2, gridColumn: 1, marginBottom: { value: 40, unit: 'px' } },
+      { gridRow: 3, gridColumn: 1, marginBottom: { value: 40, unit: 'px' } },
       {
         dimensions: {
           // eslint-disable-next-line no-nested-ternary


### PR DESCRIPTION
## Problem

Im Drag & Drop-Assistenten (Variante „Sortieren") gibt es das Feld „Überschrift" für die Elementliste. Der eingegebene Text wurde beim Anlegen des Abschnitts aber ignoriert — es wurde kein Element dafür erzeugt (#1046, Punkt 1).

## Lösung

`createSortlistSection` legt jetzt — analog zu den Varianten „Zuordnung" und „Zuordnung (2-seitig)" — ein fett formatiertes Text-Element mit der Überschrift zwischen Frage/Instruktion und der Sortierliste an.

Dazu neue Unit-Tests für `createSortlistSection` (`droplist-builders.spec.ts`).

Punkt 2 des Tickets (Format der Ziel-Ablagen bei Zuordnung) ist hiervon nicht betroffen und wird separat geklärt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)