### PR TITLE
Add narrow no-break space before colons in French email stimulus (#1045)

### DIFF
--- a/projects/editor/src/app/section-templates/builders/stimulus/stimulus-builders.spec.ts
+++ b/projects/editor/src/app/section-templates/builders/stimulus/stimulus-builders.spec.ts
@@ -1,0 +1,46 @@
+import { IDService } from 'editor/src/app/services/id.service';
+import { EmailStimulusOptions } from 'editor/src/app/section-templates/stimulus-interfaces';
+import { createEmailSection } from 'editor/src/app/section-templates/builders/stimulus/stimulus-builders';
+
+describe('createEmailSection', () => {
+  let idService: IDService;
+
+  const createOptions = (lang: 'de' | 'en' | 'fr'): EmailStimulusOptions => ({
+    instruction: 'Lies die E-Mail.',
+    from: 'sender@example.com',
+    to: 'receiver@example.com',
+    subject: 'Test',
+    body: 'Text',
+    subText: 'Untertext',
+    lang,
+    allowMarking: false
+  });
+
+  beforeEach(() => {
+    idService = new IDService();
+  });
+
+  it('should use German labels with plain colons', () => {
+    const section = JSON.stringify(createEmailSection(createOptions('de'), idService));
+    expect(section).toContain('Von:');
+    expect(section).toContain('An:');
+    expect(section).toContain('Betreff:');
+    expect(section).toContain('Senden');
+  });
+
+  it('should use English labels with plain colons', () => {
+    const section = JSON.stringify(createEmailSection(createOptions('en'), idService));
+    expect(section).toContain('From:');
+    expect(section).toContain('To:');
+    expect(section).toContain('Subject:');
+    expect(section).toContain('Send');
+  });
+
+  it('should use French labels with narrow no-break space before colons', () => {
+    const section = JSON.stringify(createEmailSection(createOptions('fr'), idService));
+    expect(section).toContain('De\u202F:');
+    expect(section).toContain('À\u202F:');
+    expect(section).toContain('Objet\u202F:');
+    expect(section).toContain('Envoyer');
+  });
+});

--- a/projects/editor/src/app/section-templates/builders/stimulus/stimulus-builders.ts
+++ b/projects/editor/src/app/section-templates/builders/stimulus/stimulus-builders.ts
@@ -38,13 +38,16 @@ export function createEmailSection(options: EmailStimulusOptions, idService: IDS
     subjectLabel = 'Subject';
     sendLabel = 'Send';
   } else if (options.lang === 'fr') {
-    fromLabel = 'De';
-    toLabel = 'À';
-    subjectLabel = 'Objet';
+    // U+202F: narrow no-break space required in French typography before colons
+    fromLabel = 'De\u202F';
+    toLabel = 'À\u202F';
+    subjectLabel = 'Objet\u202F';
     sendLabel = 'Envoyer';
   }
-  return new EditorSection(JSON.parse(getEmailTemplateString({ ...options, fromLabel, toLabel, subjectLabel, sendLabel })),
-                     idService);
+  return new EditorSection(JSON.parse(getEmailTemplateString({
+    ...options, fromLabel, toLabel, subjectLabel, sendLabel
+  })),
+                           idService);
 }
 
 export function createMessageSection(options: MessageStimulusOptions, idService: IDService): EditorSection {
@@ -55,7 +58,7 @@ export function createMessageSection(options: MessageStimulusOptions, idService:
     sendLabel = 'Répondre';
   }
   return new EditorSection(JSON.parse(getMessageTemplateString({ ...options, sendLabel })),
-                     idService);
+                           idService);
 }
 
 export function createAudio1Section(options: Audio1StimulusOptions, idService: IDService) {


### PR DESCRIPTION
## Zusammenfassung
- Im Assistenten für den Stimulus „E-Mail" (Französisch) wird zwischen den Labels **De**, **À**, **Objet** und dem folgenden Doppelpunkt ein schmales geschütztes Leerzeichen (U+202F) eingefügt, wie in der französischen Typografie üblich.
- Umsetzung über das sichtbare Escape `\u202F` in den Label-Strings in `stimulus-builders.ts`; das Template hängt den Doppelpunkt weiterhin zentral an. `Envoyer` (Senden-Button) bleibt unverändert.
- Neue Unit-Tests für `createEmailSection` (de/en/fr) in `stimulus-builders.spec.ts`.
- Nebenbei: vier vorbestehende, auto-fixbare ESLint-Fehler in der Datei behoben (Zeilenumbrüche/Einrückung).

Closes #1045

## Test
- `ng test editor --include="**/stimulus-builders.spec.ts"` → 3/3 SUCCESS
- ESLint auf beiden Dateien sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)
