### PR TITLE
Correlate widget calls and returns via callId (#1085)

### DIFF
--- a/e2e/tests/e2e/widget.spec.cy.ts
+++ b/e2e/tests/e2e/widget.spec.cy.ts
@@ -1,5 +1,14 @@
 import { addElement } from '../util';
 
+interface WidgetCallMessage {
+  callId: string;
+  parameters: { key: string, value: string }[];
+}
+
+interface PostMessageStub {
+  lastCall: { args: [WidgetCallMessage] };
+}
+
 describe('Widget Element', { testIsolation: false }, () => {
   context('editor', () => {
     before('opens an editor', () => {
@@ -47,22 +56,23 @@ describe('Widget Element', { testIsolation: false }, () => {
       cy.get('@postMessage').should('be.calledWithMatch', Cypress.sinon.match({
         type: 'vopWidgetCall',
         widgetType: 'PERIODIC_TABLE'
-      })).then((stub: any) => {
-        const lastCall = stub.lastCall;
-        const msg = lastCall.args[0];
+      })).then(stub => {
+        const msg = (stub as unknown as PostMessageStub).lastCall.args[0];
+        expect(msg.callId).to.be.a('string').with.length.greaterThan(0);
         expect(msg.parameters).to.deep.include({ key: 'SHOW_INFO_ORDER', value: 'true' });
         expect(msg.parameters).to.deep.include({ key: 'SHOW_INFO_E_NEG', value: 'false' });
         expect(msg.parameters).to.deep.include({ key: 'SHOW_INFO_A_MASS', value: 'true' });
         expect(msg.parameters).to.deep.include({ key: 'CLOSE_ON_SELECTION', value: 'false' });
         expect(msg.parameters).to.deep.include({ key: 'MAX_NUMBER_OF_SELECTIONS', value: '1' });
-      });
 
-      // Post back a vopWidgetReturn message
-      cy.window().then(window => {
-        window.postMessage({
-          type: 'vopWidgetReturn',
-          state: 'H He Li'
-        }, '*');
+        // Post back a vopWidgetReturn message echoing the callId
+        cy.window().then(window => {
+          window.postMessage({
+            type: 'vopWidgetReturn',
+            callId: msg.callId,
+            state: 'H He Li'
+          }, '*');
+        });
       });
 
       // Assert that the states are loaded and rendered
@@ -80,6 +90,9 @@ describe('Widget Element', { testIsolation: false }, () => {
         });
       });
 
+      // Open the periodic table first and "close" it without an answer (no vopWidgetReturn)
+      cy.get('aspect-widget-periodic-table button').click({ force: true });
+
       // Click molecule editor fab button
       cy.get('aspect-widget-molecule-editor button').click({ force: true });
 
@@ -87,18 +100,25 @@ describe('Widget Element', { testIsolation: false }, () => {
       cy.get('@postMessage').should('be.calledWithMatch', Cypress.sinon.match({
         type: 'vopWidgetCall',
         widgetType: 'MOLECULE_EDITOR'
-      }));
+      })).then(stub => {
+        const msg = (stub as unknown as PostMessageStub).lastCall.args[0];
+        expect(msg.callId).to.be.a('string').with.length.greaterThan(0);
 
-      // Post back a vopWidgetReturn message
-      cy.window().then(window => {
-        window.postMessage({
-          type: 'vopWidgetReturn',
-          state: 'mock-molecule-data'
-        }, '*');
+        // Post back a vopWidgetReturn message echoing the callId
+        cy.window().then(window => {
+          window.postMessage({
+            type: 'vopWidgetReturn',
+            callId: msg.callId,
+            state: 'mock-molecule-data'
+          }, '*');
+        });
       });
 
       // Assert that the molecule editor displays the state value
       cy.get('aspect-widget-molecule-editor .state-value').should('have.text', 'mock-molecule-data');
+
+      // Regression #1085: the abandoned periodic table must NOT receive the molecule editor state
+      cy.get('aspect-widget-periodic-table .element-square').should('not.exist');
     });
   });
 });

--- a/projects/player/src/app/components/elements/widget-group-element/widget-group-element.component.spec.ts
+++ b/projects/player/src/app/components/elements/widget-group-element/widget-group-element.component.spec.ts
@@ -22,7 +22,7 @@ describe('WidgetGroupElementComponent', () => {
   }
 
   class MockVeronaSubscriptionService {
-    vopWidgetReturn = new Subject<{ state: string, sessionId: string, type: 'vopWidgetReturn' }>();
+    vopWidgetReturn = new Subject<{ state: string, sessionId: string, callId?: string, type: 'vopWidgetReturn' }>();
   }
 
   beforeEach(async () => {
@@ -62,7 +62,8 @@ describe('WidgetGroupElementComponent', () => {
       maxNumberOfSelections: 3
     }, 'PERIODIC_TABLE');
 
-    expect(veronaPostService.sendVopWidgetCall).toHaveBeenCalledWith({
+    expect(veronaPostService.sendVopWidgetCall).toHaveBeenCalledWith(jasmine.objectContaining({
+      callId: jasmine.any(String),
       widgetType: 'PERIODIC_TABLE',
       parameters: [
         { key: 'SHOW_INFO_ORDER', value: 'true' },
@@ -71,10 +72,34 @@ describe('WidgetGroupElementComponent', () => {
         { key: 'CLOSE_ON_SELECTION', value: 'true' },
         { key: 'MAX_NUMBER_OF_SELECTIONS', value: '3' }
       ]
-    });
+    }));
   });
 
   it('should update elementModel state and call changeElementCodeValue on vopWidgetReturn', () => {
+    const veronaSubscriptionService = TestBed.inject(VeronaSubscriptionService);
+    const veronaPostService = TestBed.inject(VeronaPostService);
+    const sendVopWidgetCallSpy = spyOn(veronaPostService, 'sendVopWidgetCall');
+    spyOn(component, 'changeElementCodeValue');
+
+    component.applyWidgetCall({
+      showInfoOrder: true,
+      showInfoENeg: false,
+      showInfoAMass: true,
+      closeOnSelection: true,
+      maxNumberOfSelections: 3
+    }, 'PERIODIC_TABLE');
+
+    const sentCallId = sendVopWidgetCallSpy.calls.mostRecent().args[0].callId;
+    const mockReturnEvent = {
+      type: 'vopWidgetReturn' as const, sessionId: '1', callId: sentCallId, state: 'newState'
+    };
+    (veronaSubscriptionService as unknown as MockVeronaSubscriptionService).vopWidgetReturn.next(mockReturnEvent);
+
+    expect((component.elementModel as WidgetPeriodicTableElement).state).toEqual('newState');
+    expect(component.changeElementCodeValue).toHaveBeenCalledWith({ id: 'id', value: 'newState' });
+  });
+
+  it('should ignore vopWidgetReturn messages with a non-matching callId', () => {
     const veronaSubscriptionService = TestBed.inject(VeronaSubscriptionService);
     spyOn(component, 'changeElementCodeValue');
 
@@ -86,10 +111,12 @@ describe('WidgetGroupElementComponent', () => {
       maxNumberOfSelections: 3
     }, 'PERIODIC_TABLE');
 
-    const mockReturnEvent = { type: 'vopWidgetReturn' as const, sessionId: '1', state: 'newState' };
+    const mockReturnEvent = {
+      type: 'vopWidgetReturn' as const, sessionId: '1', callId: 'other-widget-call', state: 'base64FromOtherWidget'
+    };
     (veronaSubscriptionService as unknown as MockVeronaSubscriptionService).vopWidgetReturn.next(mockReturnEvent);
 
-    expect((component.elementModel as WidgetPeriodicTableElement).state).toEqual('newState');
-    expect(component.changeElementCodeValue).toHaveBeenCalledWith({ id: 'id', value: 'newState' });
+    expect((component.elementModel as WidgetPeriodicTableElement).state).toBeNull();
+    expect(component.changeElementCodeValue).not.toHaveBeenCalled();
   });
 });

--- a/projects/player/src/app/components/elements/widget-group-element/widget-group-element.component.ts
+++ b/projects/player/src/app/components/elements/widget-group-element/widget-group-element.component.ts
@@ -33,6 +33,7 @@ export class WidgetGroupElementComponent
 
   private ngUnsubscribe: Subject<void> = new Subject();
   private widgetReturnSubscription?: Subscription;
+  private currentCallId?: string;
 
   constructor(
     public unitStateService: UnitStateService,
@@ -67,6 +68,7 @@ export class WidgetGroupElementComponent
   applyWidgetCall(
     event: WidgetPeriodicTableCall | WidgetMoleculeEditorCall, widgetType: WidgetType
   ): void {
+    this.currentCallId = `${this.elementModel.alias}-${crypto.randomUUID()}`;
     this.sendWidgetCallEvent(event, widgetType);
     this.subscribeToWidgetReturn();
   }
@@ -78,6 +80,7 @@ export class WidgetGroupElementComponent
       (this.elementModel as WidgetPeriodicTableElement | WidgetMoleculeEditorElement).state;
 
     this.veronaPostService.sendVopWidgetCall({
+      callId: this.currentCallId,
       widgetType,
       parameters: Object.entries(event)
         .map(([key, value]) => ({ key: StringUtils.camelCaseToUpperSnakeCase(key), value: String(value) })),
@@ -98,6 +101,8 @@ export class WidgetGroupElementComponent
   }
 
   private handleWidgetReturnMessage(message: VopWidgetReturn): void {
+    if (message.callId !== this.currentCallId) return;
+    this.currentCallId = undefined;
     if (message.state) {
       (this.elementModel as WidgetPeriodicTableElement | WidgetMoleculeEditorElement).state =
         message.state;


### PR DESCRIPTION
## Problem (#1085)

Ein `vopWidgetReturn` wurde von **jedem** noch abonnierten Widget-Element übernommen, nicht nur von dem Element, das den Aufruf gestartet hatte. Wurde z. B. das Periodensystem geöffnet und ohne Antwort geschlossen, blieb dessen Subscription aktiv — beim anschließenden Speichern des Molekül-Editors landete dessen (Base64-)State zusätzlich im Periodensystem-Element und wurde dort als überlanges „Element" angezeigt und als Antwort gespeichert. (Gleicher Mechanismus wie früher mit dem Taschenrechner-Widget.)

## Lösung

- Der Player erzeugt für jeden `vopWidgetCall` eine eindeutige `callId` (im Verona-Widget-Protokoll bereits vorgesehen) und sendet sie mit.
- `vopWidgetReturn`-Nachrichten werden nur noch übernommen, wenn die `callId` mit der des eigenen offenen Aufrufs übereinstimmt; alle anderen werden ignoriert.
- Studio (`studio-lite`) und der Player-Testbed spiegeln die `callId` bereits zurück, es sind keine Host-Anpassungen nötig.

## Tests

- Unit-Test: Return mit fremder `callId` wird ignoriert (State bleibt `null`, kein `changeElementCodeValue`).
- E2E (`widget.spec.cy.ts`): Ticket-Szenario nachgestellt — Periodensystem öffnen/verwerfen, Molekül-Editor speichern → Periodensystem erhält keinen State. Der Test schlägt mit dem alten Code fehl und besteht mit dem Fix.

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)