### PR TITLE
Shorten generated GeoGebra source text (#1070)

### DIFF
--- a/projects/editor/src/app/section-templates/builders/geometry-builders.spec.ts
+++ b/projects/editor/src/app/section-templates/builders/geometry-builders.spec.ts
@@ -1,0 +1,33 @@
+import { IDService } from 'editor/src/app/services/id.service';
+import { TextElement } from 'common/models/elements/text/text';
+import { GeometryElement } from 'common/models/elements/geometry/geometry';
+import { ButtonElement } from 'common/models/elements/button/button';
+import { createGeometrySection } from './geometry-builders';
+
+describe('createGeometrySection', () => {
+  const sourceText = 'Erstellt mit GeoGebra, https://www.geogebra.org (es gelten die GeoGebra-Lizenzbedingungen)';
+  let idService: IDService;
+
+  beforeEach(() => {
+    idService = new IDService();
+  });
+
+  it('should create a section with text, geometry and source text elements', () => {
+    const section = createGeometrySection('Aufgabentext', 'appDef', 'file.ggb', false, sourceText, idService);
+    expect(section.elements.length).toBe(3);
+    expect((section.elements[0] as TextElement).text).toBe('Aufgabentext');
+    expect((section.elements[1] as GeometryElement).appDefinition).toBe('appDef');
+    expect((section.elements[1] as GeometryElement).fileName).toBe('file.ggb');
+  });
+
+  it('should use the given source text for the third element', () => {
+    const section = createGeometrySection('Aufgabentext', 'appDef', 'file.ggb', false, sourceText, idService);
+    expect((section.elements[2] as TextElement).text).toBe(sourceText);
+  });
+
+  it('should add a helper button when showHelper is set', () => {
+    const section = createGeometrySection('Aufgabentext', 'appDef', 'file.ggb', true, sourceText, idService);
+    expect(section.elements.length).toBe(4);
+    expect((section.elements[3] as ButtonElement).type).toBe('button');
+  });
+});

--- a/projects/editor/src/app/section-templates/builders/geometry-builders.ts
+++ b/projects/editor/src/app/section-templates/builders/geometry-builders.ts
@@ -5,7 +5,7 @@ import { TemplateService } from '../template.service';
 import { EditorSection } from '../../models/editor-unit';
 
 export function createGeometrySection(text: string, geometryAppDefinition: string, geometryFileName: string,
-                                      showHelper: boolean, idService: IDService) {
+                                      showHelper: boolean, sourceText: string, idService: IDService) {
   const sectionElements: PositionedUIElement[] = [
     TemplateService.createElement(
       'text',
@@ -27,9 +27,7 @@ export function createGeometrySection(text: string, geometryAppDefinition: strin
       'text',
       { gridRow: 3, gridColumn: 1, marginBottom: { value: 30, unit: 'px' } },
       {
-        text: 'Erstellt mit GeoGebra, https://www.geogebra.org (es gelten die GeoGebra-Lizenzbedingungen), ' +
-          'Copyright Text, Grafik und Teilaufgaben: IQB e. V., Lizenz: Creative Commons (CC BY). Volltext ' +
-          'unter: https://creativecommons.org/licenses/by/4.0/de/legalcode',
+        text: sourceText,
         styling: { fontSize: 14, lineHeight: 100 }
       },
       idService)

--- a/projects/editor/src/app/section-templates/template.service.ts
+++ b/projects/editor/src/app/section-templates/template.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
 import { RadioWizardDialogComponent } from 'editor/src/app/section-templates/dialogs/radio/radio.dialog.component';
 import { ElementFactory } from 'common/utils/element-factory';
 import { PositionProperties, PropertyGroupGenerators } from 'common/models/elements/property-group-interfaces';
@@ -52,7 +53,8 @@ export class TemplateService {
 
   constructor(private unitService: UnitService,
               private selectionService: SelectionService,
-              private idService: IDService) { }
+              private idService: IDService,
+              private translateService: TranslateService) { }
 
   static helpTooltipImageSrc = CONSTANTS.lightbulb;
 
@@ -227,6 +229,8 @@ export class TemplateService {
               if (result) {
                 resolve(GeometryBuilders.createGeometrySection(result.text, result.geometryAppDefinition,
                                                                result.geometryFileName, result.showHelper,
+                                                               this.translateService
+                                                                 .instant('sectionTemplates.geometrySource'),
                                                                this.idService));
               }
             });

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -422,6 +422,9 @@
   "error": {
     "corruptElement": "Element-Ressource ist vermutlich fehlerhaft und sollte ausgetauscht werden! \n\n Ursprüngliche Fehlermeldung: {{ errorMsg }}"
   },
+  "sectionTemplates": {
+    "geometrySource": "Erstellt mit GeoGebra, https://www.geogebra.org (es gelten die GeoGebra-Lizenzbedingungen)"
+  },
   "imageResizeDialog": {
     "title": "Bild komprimieren",
     "originalSize": "Originalgröße",


### PR DESCRIPTION
## Zusammenfassung

- Der GGB-Assistent generiert als Quelle nur noch „Erstellt mit GeoGebra, https://www.geogebra.org (es gelten die GeoGebra-Lizenzbedingungen)" — der IQB-Copyright-/CC-BY-Teil entfällt, da die IQB-Quelle künftig auf der Ende-Seite genannt wird (#1070).
- Der Text ist gemäß i18n-Regel in `editor/src/assets/i18n/de.json` hinterlegt (`sectionTemplates.geometrySource`) und wird vom `TemplateService` per `TranslateService` an den Builder durchgereicht.
- Neue Unit-Tests für `createGeometrySection` (Sektionsaufbau, Quellentext, Helper-Button).

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)