### PR TITLE
Tabelle: Optionale Kopfzeile mit Fixierung beim Scrollen (#864)

### DIFF
--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -6,6 +6,9 @@ Editor
   - Option zur automatischen Größenanpassung beim Hochladen von Bildern zur Optimierung der Dateigröße.
 - Eingabefeld, Eingabebereich (auch in Tabellen und im Lückentext)
   - Neue Eigenschaft "Textausrichtung" (linksbündig, zentriert, rechtsbündig) für den eingegebenen Text
+- Tabelle
+  - Neue optionale Kopfzeile: je Spalte ein Text mit einstellbarer Ausrichtung (linksbündig, zentriert, rechtsbündig); Bearbeitung im Dialog "Elemente anpassen"
+  - Neue Eigenschaft "Kopfzeile beim Scrollen fixieren"
 
 ### Änderungen
 - Formelfeld

--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -8,7 +8,7 @@ Editor
   - Neue Eigenschaft "Textausrichtung" (linksbündig, zentriert, rechtsbündig) für den eingegebenen Text
 - Tabelle
   - Neue optionale Kopfzeile: je Spalte ein Text mit einstellbarer Ausrichtung (linksbündig, zentriert, rechtsbündig); Bearbeitung im Dialog "Elemente anpassen"
-  - Neue Eigenschaft "Kopfzeile beim Scrollen fixieren"
+  - Neue Eigenschaft "Haftende Kopfzeile" (fixiert die Kopfzeile beim Scrollen)
 
 ### Änderungen
 - Formelfeld

--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -7,7 +7,7 @@ Editor
 - Eingabefeld, Eingabebereich (auch in Tabellen und im Lückentext)
   - Neue Eigenschaft "Textausrichtung" (linksbündig, zentriert, rechtsbündig) für den eingegebenen Text
 - Tabelle
-  - Neue optionale Kopfzeile: je Spalte ein Text mit einstellbarer Ausrichtung (linksbündig, zentriert, rechtsbündig); Bearbeitung im Dialog "Elemente anpassen"
+  - Neue optionale Kopfzeile: je Spalte ein Text mit einstellbarer Ausrichtung (linksbündig, zentriert, rechtsbündig); Bearbeitung im Dialog "Elemente anpassen", dort können auch weitere Kopfzeilen hinzugefügt und entfernt werden
   - Neue Eigenschaft "Haftende Kopfzeile" (fixiert die Kopfzeile beim Scrollen)
 
 ### Änderungen

--- a/docs/release-notes-player.md
+++ b/docs/release-notes-player.md
@@ -7,7 +7,7 @@ Player
 - Eingabefeld, Eingabebereich (auch in Tabellen und im Lückentext)
   - Die im Editor eingestellte Textausrichtung (linksbündig, zentriert, rechtsbündig) wird bei der Eingabe dargestellt
 - Tabelle
-  - Stellt die im Editor konfigurierte Kopfzeile dar; optional bleibt sie beim Scrollen am oberen Rand des sichtbaren Bereichs fixiert
+  - Stellt die im Editor konfigurierte Kopfzeile (auch mehrzeilig) dar; optional bleibt sie beim Scrollen am oberen Rand des sichtbaren Bereichs fixiert
 
 ### Änderungen
 - Eingabehilfe/Tastatur

--- a/docs/release-notes-player.md
+++ b/docs/release-notes-player.md
@@ -6,6 +6,8 @@ Player
   - Es können nun auch Aufgaben, die mit deutlich älteren Editor-Versionen erstellt wurden, im aktuellen Layout geladen und dargestellt werden
 - Eingabefeld, Eingabebereich (auch in Tabellen und im Lückentext)
   - Die im Editor eingestellte Textausrichtung (linksbündig, zentriert, rechtsbündig) wird bei der Eingabe dargestellt
+- Tabelle
+  - Stellt die im Editor konfigurierte Kopfzeile dar; optional bleibt sie beim Scrollen am oberen Rand des sichtbaren Bereichs fixiert
 
 ### Änderungen
 - Eingabehilfe/Tastatur

--- a/docs/unit_definition_changelog.txt
+++ b/docs/unit_definition_changelog.txt
@@ -246,3 +246,7 @@ iqb-aspect-definition@1.0.0
   - new type: decimals
 - TextFieldElement, TextFieldSimpleElement, TextAreaElement:
   - new property: textAlign: 'left' | 'center' | 'right'
+- TableElement:
+  - new property: headerEnabled: boolean
+  - new property: headerRows: { text: string; alignment: 'left' | 'center' | 'right' }[][]
+  - new property: stickyHeader: boolean

--- a/projects/common/assets/i18n/de.json
+++ b/projects/common/assets/i18n/de.json
@@ -13,5 +13,7 @@
   "tableHeaderText": "Kopfzeilentext",
   "tableHeaderAlignLeft": "Linksbündig",
   "tableHeaderAlignCenter": "Zentriert",
-  "tableHeaderAlignRight": "Rechtsbündig"
+  "tableHeaderAlignRight": "Rechtsbündig",
+  "tableHeaderAddRow": "Weitere Kopfzeile hinzufügen",
+  "tableHeaderRemoveRow": "Kopfzeile entfernen"
 }

--- a/projects/common/assets/i18n/de.json
+++ b/projects/common/assets/i18n/de.json
@@ -9,5 +9,9 @@
   "periodicTable": "Periodensystem",
   "calculator": "Rechner",
   "moleculeEditor": "Molekül-Editor",
-  "openWidget": "{{widget}} öffnen"
+  "openWidget": "{{widget}} öffnen",
+  "tableHeaderText": "Kopfzeilentext",
+  "tableHeaderAlignLeft": "Linksbündig",
+  "tableHeaderAlignCenter": "Zentriert",
+  "tableHeaderAlignRight": "Rechtsbündig"
 }

--- a/projects/common/components/compound-elements/table/table.component.spec.ts
+++ b/projects/common/components/compound-elements/table/table.component.spec.ts
@@ -130,5 +130,78 @@ describe('TableComponent', () => {
       expect(component.elementModel.headerRows[0][0].text).toBe('changed');
       expect(component.elementModel.headerRows[0][1].alignment).toBe('center');
     });
+
+    it('should use the given content row height while keeping header rows compact', () => {
+      component.elementModel = createTableElement(headerProperties);
+      component.contentRowHeight = '250px';
+      fixture.detectChanges();
+      const gridContainer: HTMLElement = fixture.nativeElement.querySelector('.grid-container');
+      expect(gridContainer.style.gridTemplateRows).toBe('auto 250px 250px');
+    });
+  });
+
+  describe('multiple header rows (#864)', () => {
+    const headerProperties: Partial<TableProperties> = {
+      headerEnabled: true,
+      headerRows: [[{ text: 'Column A', alignment: 'left' }, { text: 'Column B', alignment: 'right' }]]
+    };
+
+    const twoHeaderRows: Partial<TableProperties> = {
+      headerEnabled: true,
+      headerRows: [
+        [{ text: 'Group', alignment: 'center' }, { text: '', alignment: 'left' }],
+        [{ text: 'Value', alignment: 'left' }, { text: 'Unit', alignment: 'left' }]
+      ]
+    };
+
+    it('should render all header rows and move content cells below them', () => {
+      component.elementModel = createTableElement(twoHeaderRows);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('.header-cell').length).toBe(4);
+      const firstContentCell: HTMLElement = fixture.nativeElement.querySelector('.cell-container');
+      expect(firstContentCell.style.gridRowStart).toBe('3');
+      const gridContainer: HTMLElement = fixture.nativeElement.querySelector('.grid-container');
+      expect(gridContainer.style.gridTemplateRows).toBe('auto auto 1fr 1fr');
+    });
+
+    it('should stack sticky header rows by setting measured top offsets', () => {
+      component.elementModel = createTableElement({ ...twoHeaderRows, stickyHeader: true });
+      fixture.detectChanges();
+      const headerCells: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('.header-cell');
+      expect(headerCells[0].style.top).toBe('0px');
+      expect(parseFloat(headerCells[2].style.top)).toBe(headerCells[0].offsetHeight);
+    });
+
+    it('should not apply sticky positioning in the edit dialog', () => {
+      component.elementModel = createTableElement({ ...twoHeaderRows, stickyHeader: true });
+      component.allowElementEditing = true;
+      fixture.detectChanges();
+      const headerCell: HTMLElement = fixture.nativeElement.querySelector('.header-cell');
+      expect(headerCell.classList).not.toContain('sticky-header');
+      expect(headerCell.style.top).toBe('');
+    });
+
+    it('should offer adding a header row only in the last row and removing only with multiple rows', () => {
+      component.elementModel = createTableElement(headerProperties);
+      component.allowElementEditing = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('.header-row-controls button').length).toBe(1);
+
+      component.addHeaderRow();
+      fixture.detectChanges();
+      // second row: one add (last row) + two remove buttons (one per row)
+      expect(fixture.nativeElement.querySelectorAll('.header-row-controls button').length).toBe(3);
+
+      component.removeHeaderRow(1);
+      fixture.detectChanges();
+      expect(component.elementModel.headerRows.length).toBe(1);
+      expect(fixture.nativeElement.querySelectorAll('.header-row-controls button').length).toBe(1);
+    });
+
+    it('should size added header rows to the column count', () => {
+      component.elementModel = createTableElement(headerProperties);
+      component.addHeaderRow();
+      expect(component.elementModel.headerRows[1].length).toBe(2);
+    });
   });
 });

--- a/projects/common/components/compound-elements/table/table.component.spec.ts
+++ b/projects/common/components/compound-elements/table/table.component.spec.ts
@@ -1,0 +1,134 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
+import { environment } from 'common/environment';
+import { MeasurePipe } from 'common/pipes/measure.pipe';
+import { TableGridRowsPipe } from 'common/pipes/table-grid-rows.pipe';
+import { TableElement, TableProperties } from 'common/models/elements/compound-elements/table/table';
+import { TableChildOverlay } from 'common/components/compound-elements/table/table-child-overlay.component';
+import { TableComponent } from './table.component';
+
+describe('TableComponent', () => {
+  let component: TableComponent;
+  let fixture: ComponentFixture<TableComponent>;
+
+  const createTableElement = (properties: Partial<TableProperties> = {}): TableElement => new TableElement({
+    type: 'table',
+    id: 'table_1',
+    alias: 'table_1',
+    isRelevantForPresentationComplete: true,
+    elements: [],
+    gridColumnSizes: [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }],
+    gridRowSizes: [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }],
+    tableEdgesEnabled: false,
+    ...properties
+  } as TableProperties);
+
+  beforeEach(async () => {
+    environment.strictInstantiation = false;
+    await TestBed.configureTestingModule({
+      declarations: [TableComponent, TableChildOverlay, MeasurePipe, TableGridRowsPipe],
+      imports: [
+        TranslateModule.forRoot(),
+        MatIconModule, MatButtonModule, MatButtonToggleModule, MatMenuModule, MatTooltipModule
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create without a header', () => {
+    component.elementModel = createTableElement();
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+    expect(fixture.nativeElement.querySelectorAll('.header-cell').length).toBe(0);
+  });
+
+  describe('header row (#864)', () => {
+    const headerProperties: Partial<TableProperties> = {
+      headerEnabled: true,
+      headerRows: [[{ text: 'Column A', alignment: 'left' }, { text: 'Column B', alignment: 'right' }]]
+    };
+
+    it('should render one header cell per column with its text and alignment', () => {
+      component.elementModel = createTableElement(headerProperties);
+      fixture.detectChanges();
+      const headerCells: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('.header-cell');
+      expect(headerCells.length).toBe(2);
+      expect(headerCells[0].textContent).toContain('Column A');
+      expect(headerCells[0].style.textAlign).toBe('left');
+      expect(headerCells[1].textContent).toContain('Column B');
+      expect(headerCells[1].style.textAlign).toBe('right');
+    });
+
+    it('should not render header cells when the header is disabled', () => {
+      component.elementModel = createTableElement({ ...headerProperties, headerEnabled: false });
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('.header-cell').length).toBe(0);
+    });
+
+    it('should move content cells below the header row', () => {
+      component.elementModel = createTableElement(headerProperties);
+      fixture.detectChanges();
+      const firstContentCell: HTMLElement = fixture.nativeElement.querySelector('.cell-container');
+      expect(firstContentCell.style.gridRowStart).toBe('2');
+    });
+
+    it('should prepend an auto grid track for the header row', () => {
+      component.elementModel = createTableElement(headerProperties);
+      fixture.detectChanges();
+      const gridContainer: HTMLElement = fixture.nativeElement.querySelector('.grid-container');
+      expect(gridContainer.style.gridTemplateRows).toBe('auto 1fr 1fr');
+    });
+
+    it('should mark header cells as sticky when stickyHeader is set', () => {
+      component.elementModel = createTableElement({ ...headerProperties, stickyHeader: true });
+      fixture.detectChanges();
+      const headerCell: HTMLElement = fixture.nativeElement.querySelector('.header-cell');
+      expect(headerCell.classList).toContain('sticky-header');
+    });
+
+    it('should not mark header cells as sticky by default', () => {
+      component.elementModel = createTableElement(headerProperties);
+      fixture.detectChanges();
+      const headerCell: HTMLElement = fixture.nativeElement.querySelector('.header-cell');
+      expect(headerCell.classList).not.toContain('sticky-header');
+    });
+
+    it('should give header cells an opaque background for the default transparent table background', () => {
+      component.elementModel = createTableElement(headerProperties);
+      fixture.detectChanges();
+      const headerCell: HTMLElement = fixture.nativeElement.querySelector('.header-cell');
+      expect(headerCell.style.backgroundColor).toBe('white');
+    });
+
+    it('should render header texts as plain text without inputs outside of the edit dialog', () => {
+      component.elementModel = createTableElement(headerProperties);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('.header-text-input').length).toBe(0);
+    });
+
+    it('should render inputs and alignment toggles when element editing is allowed', () => {
+      component.elementModel = createTableElement(headerProperties);
+      component.allowElementEditing = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('.header-text-input').length).toBe(2);
+      expect(fixture.nativeElement.querySelectorAll('.header-alignment-toggle').length).toBe(2);
+    });
+
+    it('should update the element model on header cell changes', () => {
+      component.elementModel = createTableElement(headerProperties);
+      component.updateHeaderCellText(0, 0, 'changed');
+      component.updateHeaderCellAlignment(0, 1, 'center');
+      expect(component.elementModel.headerRows[0][0].text).toBe('changed');
+      expect(component.elementModel.headerRows[0][1].alignment).toBe('center');
+    });
+  });
+});

--- a/projects/common/components/compound-elements/table/table.component.ts
+++ b/projects/common/components/compound-elements/table/table.component.ts
@@ -1,7 +1,8 @@
 import { CompoundElementComponent } from 'common/directives/compound-element.directive';
 import { TableElement } from 'common/models/elements/compound-elements/table/table';
 import {
-  Component, OnInit,
+  AfterViewChecked, ChangeDetectorRef,
+  Component, ElementRef, HostListener, OnInit,
   Input, Output, EventEmitter,
   QueryList, ViewChildren
 } from '@angular/core';
@@ -18,15 +19,17 @@ import { UIElementType } from 'common/interfaces';
   <div class="grid-container" [style.display]="'grid'"
        [style.grid-template-columns]="elementModel.gridColumnSizes | measure"
        [style.grid-template-rows]="elementModel.gridRowSizes |
-                                   tableGridRows : (elementModel.headerEnabled ? elementModel.headerRows.length : 0)"
+                                   tableGridRows : (elementModel.headerEnabled ? elementModel.headerRows.length : 0) :
+                                                   contentRowHeight"
        [style.grid-auto-columns]="'auto'"
        [style.grid-auto-rows]="'auto'"
        [style.background-color]="elementModel.styling.backgroundColor">
     @if (elementModel.headerEnabled) {
       @for (headerRow of elementModel.headerRows; track $index; let r = $index) {
         @for (headerCell of headerRow; track $index; let j = $index) {
-          <div class="header-cell"
-               [class.sticky-header]="elementModel.stickyHeader"
+          <div class="header-cell" #headerCellElement
+               [class.sticky-header]="elementModel.stickyHeader && !allowElementEditing"
+               [style.top.px]="elementModel.stickyHeader && !allowElementEditing ? stickyHeaderOffsets[r] || 0 : null"
                [style.border-style]="elementModel.styling.borderStyle"
                [style.border-top-style]="(!elementModel.tableEdgesEnabled && r === 0) || (r > 0) ?
                                          'none' : elementModel.styling.borderStyle"
@@ -54,19 +57,39 @@ import { UIElementType } from 'common/interfaces';
                        [attr.aria-label]="'tableHeaderText' | translate"
                        [value]="headerCell.text"
                        (input)="updateHeaderCellText(r, j, $any($event.target).value)">
-                <mat-button-toggle-group class="header-alignment-toggle"
-                                         [value]="headerCell.alignment"
-                                         (change)="updateHeaderCellAlignment(r, j, $event.value)">
-                  <mat-button-toggle value="left" [matTooltip]="'tableHeaderAlignLeft' | translate">
-                    <mat-icon>format_align_left</mat-icon>
-                  </mat-button-toggle>
-                  <mat-button-toggle value="center" [matTooltip]="'tableHeaderAlignCenter' | translate">
-                    <mat-icon>format_align_center</mat-icon>
-                  </mat-button-toggle>
-                  <mat-button-toggle value="right" [matTooltip]="'tableHeaderAlignRight' | translate">
-                    <mat-icon>format_align_right</mat-icon>
-                  </mat-button-toggle>
-                </mat-button-toggle-group>
+                <div class="header-editor-actions">
+                  <mat-button-toggle-group class="header-alignment-toggle"
+                                           [value]="headerCell.alignment"
+                                           (change)="updateHeaderCellAlignment(r, j, $event.value)">
+                    <mat-button-toggle value="left" [matTooltip]="'tableHeaderAlignLeft' | translate">
+                      <mat-icon class="toggle-icon">format_align_left</mat-icon>
+                    </mat-button-toggle>
+                    <mat-button-toggle value="center" [matTooltip]="'tableHeaderAlignCenter' | translate">
+                      <mat-icon class="toggle-icon">format_align_center</mat-icon>
+                    </mat-button-toggle>
+                    <mat-button-toggle value="right" [matTooltip]="'tableHeaderAlignRight' | translate">
+                      <mat-icon class="toggle-icon">format_align_right</mat-icon>
+                    </mat-button-toggle>
+                  </mat-button-toggle-group>
+                  @if (j === 0) {
+                    <div class="header-row-controls">
+                      @if (r === elementModel.headerRows.length - 1) {
+                        <button mat-icon-button color="primary" class="row-control-button"
+                                [matTooltip]="'tableHeaderAddRow' | translate"
+                                (click)="addHeaderRow()">
+                          <mat-icon class="button-icon">add</mat-icon>
+                        </button>
+                      }
+                      @if (elementModel.headerRows.length > 1) {
+                        <button mat-icon-button color="primary" class="row-control-button"
+                                [matTooltip]="'tableHeaderRemoveRow' | translate"
+                                (click)="removeHeaderRow(r)">
+                          <mat-icon class="button-icon">remove</mat-icon>
+                        </button>
+                      }
+                    </div>
+                  }
+                </div>
               </div>
             } @else {
               {{ headerCell.text }}
@@ -135,11 +158,19 @@ import { UIElementType } from 'common/interfaces';
 `,
   styles: [`
   .header-cell {padding: 4px 8px;}
-  /* Sticks within the table's grid container; with multiple header rows only the first one stays fully visible. */
+  /* Sticks within the table's grid container; row offsets are measured and set via [style.top.px]. */
   .sticky-header {position: sticky; top: 0; z-index: 2;}
   .header-cell-editor {display: flex; flex-direction: column; gap: 4px; width: 100%;}
-  .header-text-input {width: 100%; box-sizing: border-box; text-align: inherit;}
-  .header-alignment-toggle {align-self: flex-start;}
+  .header-text-input {width: 100%; box-sizing: border-box; text-align: inherit; padding: 4px 6px;}
+  /* Fixed min-height keeps header cells the same height whether or not they hold row controls. */
+  .header-editor-actions {display: flex; align-items: center; justify-content: space-between; gap: 4px;
+                          min-height: 32px;}
+  .header-alignment-toggle {--mat-standard-button-toggle-height: 30px;}
+  .toggle-icon {font-size: 18px; width: 18px; height: 18px; line-height: 18px;}
+  .header-row-controls {display: flex; gap: 4px;}
+  .row-control-button {--mdc-icon-button-state-layer-size: 30px; width: 30px; height: 30px; padding: 3px;}
+  .row-control-button ::ng-deep .mat-mdc-button-touch-target {display: none;}
+  .button-icon {font-size: 20px; width: 20px; height: 20px; line-height: 20px;}
   .cell-container {display: flex; min-height: 50px;}
   .element-container {width: 100%; height: 100%; position: relative;}
   .cell-container > button {align-self: flex-end; justify-self: flex-start;}
@@ -148,7 +179,7 @@ import { UIElementType } from 'common/interfaces';
   .element-title {position: absolute; z-index: 1; background-color: white;}
 `]
 })
-export class TableComponent extends CompoundElementComponent implements OnInit {
+export class TableComponent extends CompoundElementComponent implements OnInit, AfterViewChecked {
   private _elementModel!: TableElement;
   @Input()
   set elementModel(value: TableElement) {
@@ -168,15 +199,50 @@ export class TableComponent extends CompoundElementComponent implements OnInit {
   /* Show add/remove buttons and element titles for managing cell elements.
      Only enabled in the table edit dialog, where the corresponding events are handled. */
   @Input() allowElementEditing: boolean = false;
+  /* Fixed height for content rows, overriding the configured row sizes.
+     Used by the table edit dialog to provide roomy cells while header rows stay compact. */
+  @Input() contentRowHeight: string | null = null;
   @Output() elementAdded = new EventEmitter<{ elementType: UIElementType, row: number, col: number }>();
   @Output() elementRemoved = new EventEmitter<{ row: number, col: number }>();
   @Output() childElementSelected = new EventEmitter<TableChildOverlay>();
   @ViewChildren(TableChildOverlay) compoundChildren!: QueryList<TableChildOverlay>;
+  @ViewChildren('headerCellElement') headerCellElements!: QueryList<ElementRef<HTMLElement>>;
 
   elementGrid: (UIElement | undefined)[][] = [];
+  stickyHeaderOffsets: number[] = [];
+
+  constructor(elementRef: ElementRef, private changeDetectorRef: ChangeDetectorRef) {
+    super(elementRef);
+  }
 
   ngOnInit(): void {
     this.initElementGrid();
+  }
+
+  ngAfterViewChecked(): void {
+    this.updateStickyHeaderOffsets();
+  }
+
+  /* Sticky header rows below the first one need their top offset set to the summed
+     height of the rows above them, so they stack instead of overlapping.
+     Skipped in the edit dialog, where sticky headers would cover the content rows. */
+  @HostListener('window:resize')
+  updateStickyHeaderOffsets(): void {
+    if (this.allowElementEditing || !this.elementModel.stickyHeader || !this.elementModel.headerEnabled) return;
+    const headerCells = this.headerCellElements ? this.headerCellElements.toArray() : [];
+    const offsets: number[] = [];
+    let cellIndex = 0;
+    let offsetSum = 0;
+    this.elementModel.headerRows.forEach(headerRow => {
+      offsets.push(offsetSum);
+      offsetSum += headerCells[cellIndex] ? headerCells[cellIndex].nativeElement.offsetHeight : 0;
+      cellIndex += headerRow.length;
+    });
+    if (offsets.length !== this.stickyHeaderOffsets.length ||
+        offsets.some((offset, index) => offset !== this.stickyHeaderOffsets[index])) {
+      this.stickyHeaderOffsets = offsets;
+      this.changeDetectorRef.detectChanges();
+    }
   }
 
   private initElementGrid(): void {
@@ -210,6 +276,14 @@ export class TableComponent extends CompoundElementComponent implements OnInit {
 
   updateHeaderCellAlignment(rowIndex: number, colIndex: number, alignment: 'left' | 'center' | 'right'): void {
     this.elementModel.headerRows[rowIndex][colIndex].alignment = alignment;
+  }
+
+  addHeaderRow(): void {
+    this.elementModel.addHeaderRow();
+  }
+
+  removeHeaderRow(rowIndex: number): void {
+    this.elementModel.removeHeaderRow(rowIndex);
   }
 
   getFormElementChildrenComponents(): ElementComponent[] {

--- a/projects/common/components/compound-elements/table/table.component.ts
+++ b/projects/common/components/compound-elements/table/table.component.ts
@@ -17,15 +17,70 @@ import { UIElementType } from 'common/interfaces';
   template: `
   <div class="grid-container" [style.display]="'grid'"
        [style.grid-template-columns]="elementModel.gridColumnSizes | measure"
-       [style.grid-template-rows]="elementModel.gridRowSizes | measure"
+       [style.grid-template-rows]="elementModel.gridRowSizes |
+                                   tableGridRows : (elementModel.headerEnabled ? elementModel.headerRows.length : 0)"
        [style.grid-auto-columns]="'auto'"
        [style.grid-auto-rows]="'auto'"
        [style.background-color]="elementModel.styling.backgroundColor">
+    @if (elementModel.headerEnabled) {
+      @for (headerRow of elementModel.headerRows; track $index; let r = $index) {
+        @for (headerCell of headerRow; track $index; let j = $index) {
+          <div class="header-cell"
+               [class.sticky-header]="elementModel.stickyHeader"
+               [style.border-style]="elementModel.styling.borderStyle"
+               [style.border-top-style]="(!elementModel.tableEdgesEnabled && r === 0) || (r > 0) ?
+                                         'none' : elementModel.styling.borderStyle"
+               [style.border-left-style]="(!elementModel.tableEdgesEnabled && j === 0) || (j > 0) ?
+                                          'none' : elementModel.styling.borderStyle"
+               [style.border-right-style]="(!elementModel.tableEdgesEnabled && j === headerRow.length - 1) ?
+                                           'none' : elementModel.styling.borderStyle"
+               [style.border-width.px]="elementModel.styling.borderWidth"
+               [style.border-color]="elementModel.styling.borderColor"
+               [style.border-radius.px]="elementModel.styling.borderRadius"
+               [style.background-color]="elementModel.styling.backgroundColor === 'transparent' ?
+                                         'white' : elementModel.styling.backgroundColor"
+               [style.color]="elementModel.styling.fontColor"
+               [style.font-family]="elementModel.styling.font"
+               [style.font-size.px]="elementModel.styling.fontSize"
+               [style.font-weight]="elementModel.styling.bold ? 'bold' : ''"
+               [style.font-style]="elementModel.styling.italic ? 'italic' : ''"
+               [style.text-decoration]="elementModel.styling.underline ? 'underline' : ''"
+               [style.text-align]="headerCell.alignment"
+               [style.grid-row-start]="r + 1"
+               [style.grid-column-start]="j + 1">
+            @if (allowElementEditing) {
+              <div class="header-cell-editor">
+                <input class="header-text-input"
+                       [attr.aria-label]="'tableHeaderText' | translate"
+                       [value]="headerCell.text"
+                       (input)="updateHeaderCellText(r, j, $any($event.target).value)">
+                <mat-button-toggle-group class="header-alignment-toggle"
+                                         [value]="headerCell.alignment"
+                                         (change)="updateHeaderCellAlignment(r, j, $event.value)">
+                  <mat-button-toggle value="left" [matTooltip]="'tableHeaderAlignLeft' | translate">
+                    <mat-icon>format_align_left</mat-icon>
+                  </mat-button-toggle>
+                  <mat-button-toggle value="center" [matTooltip]="'tableHeaderAlignCenter' | translate">
+                    <mat-icon>format_align_center</mat-icon>
+                  </mat-button-toggle>
+                  <mat-button-toggle value="right" [matTooltip]="'tableHeaderAlignRight' | translate">
+                    <mat-icon>format_align_right</mat-icon>
+                  </mat-button-toggle>
+                </mat-button-toggle-group>
+              </div>
+            } @else {
+              {{ headerCell.text }}
+            }
+          </div>
+        }
+      }
+    }
     <ng-container *ngFor="let row of elementGrid; let i = index;">
       <div *ngFor="let _ of row; let j = index;"
            class="cell-container"
            [style.border-style]="elementModel.styling.borderStyle"
-           [style.border-top-style]="(!elementModel.tableEdgesEnabled && i === 0) || (i > 0) ?
+           [style.border-top-style]="(elementModel.headerEnabled && elementModel.headerRows.length > 0) ||
+                                     (!elementModel.tableEdgesEnabled && i === 0) || (i > 0) ?
                                      'none' : elementModel.styling.borderStyle"
            [style.border-bottom-style]="(!elementModel.tableEdgesEnabled && i === elementGrid.length - 1) ?
                                         'none' : elementModel.styling.borderStyle"
@@ -36,7 +91,7 @@ import { UIElementType } from 'common/interfaces';
            [style.border-width.px]="elementModel.styling.borderWidth"
            [style.border-color]="elementModel.styling.borderColor"
            [style.border-radius.px]="elementModel.styling.borderRadius"
-           [style.grid-row-start]="i + 1"
+           [style.grid-row-start]="i + 1 + (elementModel.headerEnabled ? elementModel.headerRows.length : 0)"
            [style.grid-column-start]="j + 1">
         <ng-container *ngIf="elementGrid[i][j] === undefined && allowElementEditing">
           <button mat-mini-fab color="primary" class="button"
@@ -79,6 +134,12 @@ import { UIElementType } from 'common/interfaces';
   </div>
 `,
   styles: [`
+  .header-cell {padding: 4px 8px;}
+  /* Sticks within the table's grid container; with multiple header rows only the first one stays fully visible. */
+  .sticky-header {position: sticky; top: 0; z-index: 2;}
+  .header-cell-editor {display: flex; flex-direction: column; gap: 4px; width: 100%;}
+  .header-text-input {width: 100%; box-sizing: border-box; text-align: inherit;}
+  .header-alignment-toggle {align-self: flex-start;}
   .cell-container {display: flex; min-height: 50px;}
   .element-container {width: 100%; height: 100%; position: relative;}
   .cell-container > button {align-self: flex-end; justify-self: flex-start;}
@@ -141,6 +202,14 @@ export class TableComponent extends CompoundElementComponent implements OnInit {
 
   addElement(elementType: UIElementType, row: number, col: number): void {
     this.elementAdded.emit({ elementType, row, col });
+  }
+
+  updateHeaderCellText(rowIndex: number, colIndex: number, text: string): void {
+    this.elementModel.headerRows[rowIndex][colIndex].text = text;
+  }
+
+  updateHeaderCellAlignment(rowIndex: number, colIndex: number, alignment: 'left' | 'center' | 'right'): void {
+    this.elementModel.headerRows[rowIndex][colIndex].alignment = alignment;
   }
 
   getFormElementChildrenComponents(): ElementComponent[] {

--- a/projects/common/interfaces.ts
+++ b/projects/common/interfaces.ts
@@ -11,6 +11,7 @@ import {
 import { VisibilityRule } from 'common/models/visibility-rule';
 import { UIElement } from 'common/models/elements/element';
 import { MathTableRow } from 'common/models/elements/input-elements/math-table';
+import { TableHeaderCell } from 'common/models/elements/compound-elements/table/table';
 import { Markable } from 'player/src/app/models/markable.interface';
 import { TextAreaMath } from 'common/models/elements/input-elements/text-area-math';
 
@@ -116,7 +117,8 @@ export interface ValueChangeElement {
 
 export type UIElementValue = string | number | boolean | undefined | UIElementType | InputElementValue |
 TextLabel | TextLabel[] | ClozeDocument | LikertRowElement[] | Hotspot[] | StateVariable | GeometryVariable[] |
-PositionProperties | PlayerProperties | Measurement | Measurement[] | VisibilityRule[] | UIElement[];
+PositionProperties | PlayerProperties | Measurement | Measurement[] | VisibilityRule[] | UIElement[] |
+TableHeaderCell[][];
 
 export type InputAssistancePreset = null | 'french' | 'numbers' | 'decimals' | 'numbersAndOperators' |
 'numbersAndBasicOperators' | 'comparisonOperators' | 'chemicalEquation' | 'squareDashDot' | 'placeValue' |

--- a/projects/common/models/elements/compound-elements/table/table.spec.ts
+++ b/projects/common/models/elements/compound-elements/table/table.spec.ts
@@ -78,6 +78,101 @@ describe('TableElement', () => {
     expect(table.getChildElements()[0]).toBeInstanceOf(DropListElement);
   });
 
+  describe('header row (#864)', () => {
+    const twoColumnTableProperties = {
+      ...tableProperties,
+      elements: [],
+      gridColumnSizes: [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }]
+    };
+
+    it('should fall back to disabled header for definitions without header properties', () => {
+      const table = new TableElement(tableProperties);
+      expect(table.headerEnabled).toBe(false);
+      expect(table.headerRows).toEqual([]);
+      expect(table.stickyHeader).toBe(false);
+    });
+
+    it('should apply given header properties', () => {
+      const table = new TableElement({
+        ...twoColumnTableProperties,
+        headerEnabled: true,
+        headerRows: [[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }]],
+        stickyHeader: true
+      });
+      expect(table.headerEnabled).toBe(true);
+      expect(table.headerRows).toEqual([[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }]]);
+      expect(table.stickyHeader).toBe(true);
+    });
+
+    it('should copy header cells instead of keeping blueprint references', () => {
+      const headerRows: { text: string; alignment: 'left' | 'center' | 'right' }[][] =
+        [[{ text: 'A', alignment: 'left' }]];
+      const table = new TableElement({ ...tableProperties, headerEnabled: true, headerRows });
+      headerRows[0][0].text = 'changed';
+      expect(table.headerRows[0][0].text).toBe('A');
+    });
+
+    it('should create a header row matching the column count when the header gets enabled', () => {
+      const table = new TableElement(twoColumnTableProperties);
+      table.setProperty('headerEnabled', true);
+      expect(table.headerRows).toEqual([
+        [{ text: '', alignment: 'left' }, { text: '', alignment: 'left' }]
+      ]);
+    });
+
+    it('should keep existing header rows when the header gets re-enabled', () => {
+      const table = new TableElement({
+        ...tableProperties,
+        headerRows: [[{ text: 'A', alignment: 'center' }]]
+      });
+      table.setProperty('headerEnabled', true);
+      expect(table.headerRows).toEqual([[{ text: 'A', alignment: 'center' }]]);
+    });
+
+    it('should extend header rows when columns are added', () => {
+      const table = new TableElement({
+        ...tableProperties,
+        headerEnabled: true,
+        headerRows: [[{ text: 'A', alignment: 'center' }]]
+      });
+      table.setProperty('gridColumnSizes', [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }]);
+      expect(table.headerRows).toEqual([
+        [{ text: 'A', alignment: 'center' }, { text: '', alignment: 'left' }]
+      ]);
+    });
+
+    it('should shrink header rows when columns are removed', () => {
+      const table = new TableElement({
+        ...twoColumnTableProperties,
+        headerEnabled: true,
+        headerRows: [[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }]]
+      });
+      table.setProperty('gridColumnSizes', [{ value: 1, unit: 'fr' }]);
+      expect(table.headerRows).toEqual([[{ text: 'A', alignment: 'left' }]]);
+    });
+
+    it('should replace header row arrays on setProperty, so components get updated', () => {
+      const table = new TableElement(twoColumnTableProperties);
+      const originalHeaderRows = table.headerRows;
+      table.setProperty('headerRows', [[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'left' }]]);
+      expect(table.headerRows).not.toBe(originalHeaderRows);
+      expect(table.headerRows[0][0]).toEqual({ text: 'A', alignment: 'left' });
+    });
+
+    it('should keep header properties in the blueprint', () => {
+      const table = new TableElement({
+        ...twoColumnTableProperties,
+        headerEnabled: true,
+        headerRows: [[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }]],
+        stickyHeader: true
+      });
+      const blueprint = table.getBlueprint();
+      expect(blueprint.headerEnabled).toBe(true);
+      expect(blueprint.headerRows).toEqual([[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }]]);
+      expect(blueprint.stickyHeader).toBe(true);
+    });
+  });
+
   describe('getVariableInfos of a section with a drop list inside a table (#1087)', () => {
     it('should not throw', () => {
       const section = new Section(createSectionProperties([tableProperties as UIElementProperties]));

--- a/projects/common/models/elements/compound-elements/table/table.spec.ts
+++ b/projects/common/models/elements/compound-elements/table/table.spec.ts
@@ -159,6 +159,34 @@ describe('TableElement', () => {
       expect(table.headerRows[0][0]).toEqual({ text: 'A', alignment: 'left' });
     });
 
+    it('should append an empty header row matching the column count on addHeaderRow', () => {
+      const table = new TableElement({
+        ...twoColumnTableProperties,
+        headerEnabled: true,
+        headerRows: [[{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }]]
+      });
+      const originalHeaderRows = table.headerRows;
+      table.addHeaderRow();
+      expect(table.headerRows).toEqual([
+        [{ text: 'A', alignment: 'left' }, { text: 'B', alignment: 'right' }],
+        [{ text: '', alignment: 'left' }, { text: '', alignment: 'left' }]
+      ]);
+      expect(table.headerRows).not.toBe(originalHeaderRows);
+    });
+
+    it('should remove the header row at the given index on removeHeaderRow', () => {
+      const table = new TableElement({
+        ...tableProperties,
+        headerEnabled: true,
+        headerRows: [
+          [{ text: 'A', alignment: 'left' }],
+          [{ text: 'B', alignment: 'center' }]
+        ]
+      });
+      table.removeHeaderRow(0);
+      expect(table.headerRows).toEqual([[{ text: 'B', alignment: 'center' }]]);
+    });
+
     it('should keep header properties in the blueprint', () => {
       const table = new TableElement({
         ...twoColumnTableProperties,

--- a/projects/common/models/elements/compound-elements/table/table.ts
+++ b/projects/common/models/elements/compound-elements/table/table.ts
@@ -90,6 +90,14 @@ export class TableElement extends CompoundElement implements TableProperties {
     }
   }
 
+  addHeaderRow(): void {
+    this.headerRows = [...this.headerRows, TableElement.createHeaderRow(this.gridColumnSizes.length)];
+  }
+
+  removeHeaderRow(rowIndex: number): void {
+    this.headerRows = this.headerRows.filter((_, index) => index !== rowIndex);
+  }
+
   private adjustHeaderRowsToColumnCount(): void {
     const columnCount = this.gridColumnSizes.length;
     this.headerRows = this.headerRows.map(row => [

--- a/projects/common/models/elements/compound-elements/table/table.ts
+++ b/projects/common/models/elements/compound-elements/table/table.ts
@@ -29,6 +29,9 @@ export class TableElement extends CompoundElement implements TableProperties {
 
   elements: UIElement[] = [];
   tableEdgesEnabled: boolean = ELEMENT_DEFAULTS.table.tableEdgesEnabled as boolean;
+  headerEnabled: boolean = ELEMENT_DEFAULTS.table.headerEnabled as boolean;
+  headerRows: TableHeaderCell[][] = [];
+  stickyHeader: boolean = ELEMENT_DEFAULTS.table.stickyHeader as boolean;
   position: PositionProperties = PropertyGroupGenerators.generatePositionProps(ELEMENT_DEFAULTS.table);
 
   dimensions: DimensionProperties = PropertyGroupGenerators.generateDimensionProps(ELEMENT_DEFAULTS.table);
@@ -56,6 +59,11 @@ export class TableElement extends CompoundElement implements TableProperties {
         return childElement;
       });
       this.tableEdgesEnabled = element.tableEdgesEnabled;
+      if (element.headerEnabled !== undefined) this.headerEnabled = element.headerEnabled;
+      if (element.headerRows !== undefined) {
+        this.headerRows = element.headerRows.map(row => row.map(cell => ({ ...cell })));
+      }
+      if (element.stickyHeader !== undefined) this.stickyHeader = element.stickyHeader;
       this.position = { ...this.position, ...element.position };
       this.dimensions = { ...this.dimensions, ...element.dimensions };
       this.styling = { ...this.styling, ...element.styling } as BasicStyles & BorderStyles;
@@ -68,9 +76,30 @@ export class TableElement extends CompoundElement implements TableProperties {
     if (property === 'gridColumnSizes' || property === 'gridRowSizes') {
       // Don't preserve original array, so Component gets updated
       this[property] = value as { value: number; unit: string }[];
+      if (property === 'gridColumnSizes') this.adjustHeaderRowsToColumnCount();
+    } else if (property === 'headerRows') {
+      // Don't preserve original arrays, so Component gets updated
+      this.headerRows = (value as TableHeaderCell[][]).map(row => row.map(cell => ({ ...cell })));
+    } else if (property === 'headerEnabled') {
+      this.headerEnabled = value as boolean;
+      if (this.headerEnabled && this.headerRows.length === 0) {
+        this.headerRows = [TableElement.createHeaderRow(this.gridColumnSizes.length)];
+      }
     } else {
       super.setProperty(property, value);
     }
+  }
+
+  private adjustHeaderRowsToColumnCount(): void {
+    const columnCount = this.gridColumnSizes.length;
+    this.headerRows = this.headerRows.map(row => [
+      ...row.slice(0, columnCount).map(cell => ({ ...cell })),
+      ...TableElement.createHeaderRow(Math.max(columnCount - row.length, 0))
+    ]);
+  }
+
+  private static createHeaderRow(columnCount: number): TableHeaderCell[] {
+    return Array.from({ length: columnCount }, (): TableHeaderCell => ({ text: '', alignment: 'left' }));
   }
 
   getChildElements(): UIElement[] {
@@ -87,11 +116,19 @@ export class TableElement extends CompoundElement implements TableProperties {
   }
 }
 
+export interface TableHeaderCell {
+  text: string;
+  alignment: 'left' | 'center' | 'right';
+}
+
 export interface TableProperties extends UIElementProperties {
   gridColumnSizes: { value: number; unit: string }[];
   gridRowSizes: { value: number; unit: string }[];
   elements: UIElementProperties[];
   tableEdgesEnabled: boolean;
+  headerEnabled: boolean;
+  headerRows: TableHeaderCell[][];
+  stickyHeader: boolean;
   position: PositionProperties;
   styling: BasicStyles & BorderStyles;
 }

--- a/projects/common/models/elements/element-registry.ts
+++ b/projects/common/models/elements/element-registry.ts
@@ -355,6 +355,9 @@ export const ELEMENT_DEFAULTS: Record<string, Record<string, unknown>> = {
     gridRowSizes: [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }],
     elements: [],
     tableEdgesEnabled: false,
+    headerEnabled: false,
+    headerRows: [],
+    stickyHeader: false,
     marginBottom: { value: 30, unit: 'px' },
     borderWidth: 1,
     backgroundColor: 'transparent'

--- a/projects/common/pipes/table-grid-rows.pipe.spec.ts
+++ b/projects/common/pipes/table-grid-rows.pipe.spec.ts
@@ -16,4 +16,9 @@ describe('TableGridRowsPipe', () => {
   it('should handle empty row sizes', () => {
     expect(pipe.transform([], 1)).toBe('auto');
   });
+
+  it('should override content row sizes while keeping header tracks at auto', () => {
+    expect(pipe.transform(gridRowSizes, 1, '250px')).toBe('auto 250px 250px');
+    expect(pipe.transform(gridRowSizes, 0, '250px')).toBe('250px 250px');
+  });
 });

--- a/projects/common/pipes/table-grid-rows.pipe.spec.ts
+++ b/projects/common/pipes/table-grid-rows.pipe.spec.ts
@@ -1,0 +1,19 @@
+import { TableGridRowsPipe } from './table-grid-rows.pipe';
+
+describe('TableGridRowsPipe', () => {
+  const pipe = new TableGridRowsPipe();
+  const gridRowSizes = [{ value: 1, unit: 'fr' }, { value: 50, unit: 'px' }];
+
+  it('should return the plain row sizes without header rows', () => {
+    expect(pipe.transform(gridRowSizes, 0)).toBe('1fr 50px');
+  });
+
+  it('should prepend an auto track for each header row', () => {
+    expect(pipe.transform(gridRowSizes, 1)).toBe('auto 1fr 50px');
+    expect(pipe.transform(gridRowSizes, 2)).toBe('auto auto 1fr 50px');
+  });
+
+  it('should handle empty row sizes', () => {
+    expect(pipe.transform([], 1)).toBe('auto');
+  });
+});

--- a/projects/common/pipes/table-grid-rows.pipe.ts
+++ b/projects/common/pipes/table-grid-rows.pipe.ts
@@ -6,10 +6,10 @@ import { Measurement } from 'common/interfaces';
   standalone: false
 })
 export class TableGridRowsPipe implements PipeTransform {
-  transform(gridRowSizes: Measurement[], headerRowCount: number): string {
+  transform(gridRowSizes: Measurement[], headerRowCount: number, contentRowHeight: string | null = null): string {
     return [
       ...Array(headerRowCount).fill('auto'),
-      ...gridRowSizes.map(size => String(size.value) + size.unit)
+      ...gridRowSizes.map(size => contentRowHeight ?? String(size.value) + size.unit)
     ].join(' ');
   }
 }

--- a/projects/common/pipes/table-grid-rows.pipe.ts
+++ b/projects/common/pipes/table-grid-rows.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Measurement } from 'common/interfaces';
+
+@Pipe({
+  name: 'tableGridRows',
+  standalone: false
+})
+export class TableGridRowsPipe implements PipeTransform {
+  transform(gridRowSizes: Measurement[], headerRowCount: number): string {
+    return [
+      ...Array(headerRowCount).fill('auto'),
+      ...gridRowSizes.map(size => String(size.value) + size.unit)
+    ].join(' ');
+  }
+}

--- a/projects/common/shared.module.ts
+++ b/projects/common/shared.module.ts
@@ -108,6 +108,7 @@ import { ImageSrcPipe } from './pipes/image-src.pipe';
 import { TableComponent } from './components/compound-elements/table/table.component';
 import { TableChildOverlay } from './components/compound-elements/table/table-child-overlay.component';
 import { MeasurePipe } from './pipes/measure.pipe';
+import { TableGridRowsPipe } from './pipes/table-grid-rows.pipe';
 import { MarkingPanelComponent } from './components/text/marking-panel.component';
 
 @NgModule({
@@ -174,7 +175,8 @@ import { MarkingPanelComponent } from './components/text/marking-panel.component
     TableComponent,
     TableChildOverlay,
     MarkingPanelComponent,
-    MeasurePipe
+    MeasurePipe,
+    TableGridRowsPipe
   ],
   exports: [
     CommonModule,
@@ -224,7 +226,8 @@ import { MarkingPanelComponent } from './components/text/marking-panel.component
     TableComponent,
     TableChildOverlay,
     MarkingPanelComponent,
-    MeasurePipe
+    MeasurePipe,
+    TableGridRowsPipe
   ],
   imports: [
     CommonModule,

--- a/projects/editor/src/app/components/dialogs/table-edit-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/table-edit-dialog.component.ts
@@ -32,7 +32,9 @@ import { firstValueFrom } from 'rxjs';
                     (elementRemoved)="removeElement($event)"></aspect-table>
     </mat-dialog-content>
     <mat-dialog-actions>
-      <button mat-button [mat-dialog-close]="newTable.elements">{{'save' | translate }}</button>
+      <button mat-button [mat-dialog-close]="{ elements: newTable.elements, headerRows: newTable.headerRows }">
+        {{'save' | translate }}
+      </button>
       <button mat-button mat-dialog-close>{{'cancel' | translate }}</button>
     </mat-dialog-actions>
   `,
@@ -42,6 +44,10 @@ import { firstValueFrom } from 'rxjs';
       grid-template-rows: unset !important;
       grid-auto-columns: 300px !important;
       grid-auto-rows: 250px !important;
+    }
+    :host ::ng-deep aspect-table .header-cell {
+      display: flex;
+      align-items: center;
     }
   `
 })

--- a/projects/editor/src/app/components/dialogs/table-edit-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/table-edit-dialog.component.ts
@@ -28,6 +28,7 @@ import { firstValueFrom } from 'rxjs';
     <div mat-dialog-title>Tabellenelemente</div>
     <mat-dialog-content>
       <aspect-table [elementModel]="newTable" [editorMode]="true" [allowElementEditing]="true"
+                    [contentRowHeight]="'250px'"
                     (elementAdded)="addElement($event)"
                     (elementRemoved)="removeElement($event)"></aspect-table>
     </mat-dialog-content>
@@ -41,9 +42,7 @@ import { firstValueFrom } from 'rxjs';
   styles: `
     :host ::ng-deep aspect-table .grid-container {
       grid-template-columns: unset !important;
-      grid-template-rows: unset !important;
       grid-auto-columns: 300px !important;
-      grid-auto-rows: 250px !important;
     }
     :host ::ng-deep aspect-table .header-cell {
       display: flex;

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/element-model-properties.component.html
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/element-model-properties.component.html
@@ -182,7 +182,9 @@
                                       (updateModel)="updateModel.emit($event)">
   </aspect-input-assistance-properties>
 
-  <mat-checkbox *ngIf="unitService.expertMode && combinedProperties.stickyHeader !== undefined"
+  <!-- Tables get their own conditional stickyHeader checkbox in aspect-table-properties. -->
+  <mat-checkbox *ngIf="unitService.expertMode && combinedProperties.stickyHeader !== undefined &&
+                       combinedProperties.type !== 'table'"
                 [checked]="$any(combinedProperties.stickyHeader)"
                 (change)="updateModel.emit({ property: 'stickyHeader', value: $event.checked })">
     {{'propertiesPanel.stickyHeader' | translate }}

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/element-model-properties.component.html
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/element-model-properties.component.html
@@ -182,9 +182,9 @@
                                       (updateModel)="updateModel.emit($event)">
   </aspect-input-assistance-properties>
 
-  <!-- Tables get their own conditional stickyHeader checkbox in aspect-table-properties. -->
-  <mat-checkbox *ngIf="unitService.expertMode && combinedProperties.stickyHeader !== undefined &&
-                       combinedProperties.type !== 'table'"
+  <mat-checkbox *ngIf="combinedProperties.stickyHeader !== undefined &&
+                       (combinedProperties.type !== 'likert' || unitService.expertMode) &&
+                       (combinedProperties.type !== 'table' || $any(combinedProperties).headerEnabled)"
                 [checked]="$any(combinedProperties.stickyHeader)"
                 (change)="updateModel.emit({ property: 'stickyHeader', value: $event.checked })">
     {{'propertiesPanel.stickyHeader' | translate }}

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/element-model-properties.component.html
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/element-model-properties.component.html
@@ -183,9 +183,9 @@
   </aspect-input-assistance-properties>
 
   <mat-checkbox *ngIf="combinedProperties.stickyHeader !== undefined &&
-                       (combinedProperties.type !== 'likert' || unitService.expertMode) &&
-                       (combinedProperties.type !== 'table' || $any(combinedProperties).headerEnabled)"
+                       (combinedProperties.type !== 'likert' || unitService.expertMode)"
                 [checked]="$any(combinedProperties.stickyHeader)"
+                [disabled]="combinedProperties.type === 'table' && !$any(combinedProperties).headerEnabled"
                 (change)="updateModel.emit({ property: 'stickyHeader', value: $event.checked })">
     {{'propertiesPanel.stickyHeader' | translate }}
   </mat-checkbox>

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/table-properties.component.ts
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/table-properties.component.ts
@@ -74,12 +74,6 @@ import { Subject } from 'rxjs';
                   (change)="updateModel.emit({ property: 'headerEnabled', value: $event.checked })">
       {{'propertiesPanel.tableHeaderEnabled' | translate }}
     </mat-checkbox>
-    @if ($any(combinedProperties).headerEnabled) {
-      <mat-checkbox [checked]="$any(combinedProperties).stickyHeader"
-                    (change)="updateModel.emit({ property: 'stickyHeader', value: $event.checked })">
-        {{'propertiesPanel.tableStickyHeader' | translate }}
-      </mat-checkbox>
-    }
   `,
   styles: ':host {display: flex; flex-direction: column;}'
 })

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/table-properties.component.ts
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/table-properties.component.ts
@@ -70,6 +70,16 @@ import { Subject } from 'rxjs';
                   (change)="updateModel.emit({ property: 'tableEdgesEnabled', value: $event.checked })">
       Tabellenränder zeichnen
     </mat-checkbox>
+    <mat-checkbox [checked]="$any(combinedProperties).headerEnabled"
+                  (change)="updateModel.emit({ property: 'headerEnabled', value: $event.checked })">
+      {{'propertiesPanel.tableHeaderEnabled' | translate }}
+    </mat-checkbox>
+    @if ($any(combinedProperties).headerEnabled) {
+      <mat-checkbox [checked]="$any(combinedProperties).stickyHeader"
+                    (change)="updateModel.emit({ property: 'stickyHeader', value: $event.checked })">
+        {{'propertiesPanel.tableStickyHeader' | translate }}
+      </mat-checkbox>
+    }
   `,
   styles: ':host {display: flex; flex-direction: column;}'
 })

--- a/projects/editor/src/app/services/element.service.ts
+++ b/projects/editor/src/app/services/element.service.ts
@@ -25,7 +25,7 @@ import { MessageService } from 'editor/src/app/services/message.service';
 import { TextElement } from 'common/models/elements/text/text';
 import { ClozeDocument, ClozeElement } from 'common/models/elements/compound-elements/cloze/cloze';
 import { DomSanitizer } from '@angular/platform-browser';
-import { TableElement } from 'common/models/elements/compound-elements/table/table';
+import { TableElement, TableHeaderCell } from 'common/models/elements/compound-elements/table/table';
 import {
   DragNDropValueObject,
   PositionedUIElement,
@@ -320,9 +320,10 @@ export class ElementService {
         break;
       case 'table':
         this.dialogService.showTableEditDialog(element as TableElement)
-          .subscribe((result: UIElement[]) => {
+          .subscribe((result: { elements: UIElement[], headerRows: TableHeaderCell[][] }) => {
             if (result) {
-              this.updateElementsProperty([element], 'elements', result);
+              this.updateElementsProperty([element], 'elements', result.elements);
+              this.updateElementsProperty([element], 'headerRows', result.headerRows);
             }
           });
         break;

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -80,7 +80,6 @@
   "propertiesPanel": {
     "asLink": "als Hyperlink-Text darstellen",
     "tableHeaderEnabled": "Kopfzeile anzeigen",
-    "tableStickyHeader": "Kopfzeile beim Scrollen fixieren",
     "textAlign": "Textausrichtung",
     "textAlignLeft": "linksbündig",
     "textAlignCenter": "zentriert",

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -79,6 +79,8 @@
   },
   "propertiesPanel": {
     "asLink": "als Hyperlink-Text darstellen",
+    "tableHeaderEnabled": "Kopfzeile anzeigen",
+    "tableStickyHeader": "Kopfzeile beim Scrollen fixieren",
     "textAlign": "Textausrichtung",
     "textAlignLeft": "linksbündig",
     "textAlignCenter": "zentriert",


### PR DESCRIPTION
Closes #864

## Umsetzung

Tabellen erhalten eine dedizierte, optionale **Kopfzeile**:

- Je Spalte ein Text mit einstellbarer Ausrichtung (linksbündig, zentriert, rechtsbündig)
- Die Schrift-Einstellungen aus den Style-Properties der Tabelle (Schriftart, -größe, -farbe, fett/kursiv/unterstrichen) wirken auf die Kopfzeile
- Optional kann die Kopfzeile beim Scrollen am oberen Rand des Sichtbereichs fixiert werden (`position: sticky`; Begrenzung ist der Grid-Container der Tabelle, d. h. die Kopfzeile scrollt mit dem Tabellenende wieder heraus)
- **Mehrere Kopfzeilen** sind möglich (z. B. Messgröße + Einheit in NaWi); fixierte Kopfzeilen stapeln sich beim Scrollen untereinander (gemessene Top-Offsets je Zeile)

## Bedienung im Editor

- **Eigenschaftsinspektor:** neue Checkbox „Kopfzeile anzeigen"; die vorhandene generische Checkbox „Haftende Kopfzeile" (wie bei der Likert-Matrix, dort weiterhin nur im Expertenmodus) ist ohne aktive Kopfzeile deaktiviert
- **Dialog „Elemente anpassen":** dort werden die Kopfzeilen-Texte inline bearbeitet (Eingabefeld + kompakter Ausrichtungs-Toggle je Spalte); über kleine Icon-Buttons in der ersten Spalte können weitere Kopfzeilen hinzugefügt und entfernt werden
- Im Dialog ist die Sticky-Positionierung unterdrückt (sie würde die Inhaltszeilen verdecken); die Inhaltszeilen behalten ihre 250px-Arbeitshöhe über den neuen `contentRowHeight`-Input der Tabellen-Komponente statt per CSS-Override

## Datenmodell

- `TableElement`: neue Properties `headerEnabled: boolean`, `headerRows: TableHeaderCell[][]`, `stickyHeader: boolean` (Unit-Definition 4.12.0, abwärtskompatibel — alte Definitionen laden unverändert; `stickyHeader` benannt wie bei Likert)
- Verwaltung über `addHeaderRow()`/`removeHeaderRow()`; bei Änderung der Spaltenanzahl werden die Kopfzeilen automatisch synchron gehalten

## Doku

- Release-Notes für Editor und Player (3.0.0) ergänzt

## Tests

- Modell-Tests (Defaults, Konstruktor, Spalten-Sync, Blueprint, Zeilen-Verwaltung)
- Komponenten-Tests (Rendering, Alignment, Sticky-Klasse und -Offsets, deckender Hintergrund, Edit-Modus inkl. unterdrücktem Sticky)
- Pipe-Tests für die Grid-Zeilen-Berechnung
- Alle Suiten grün: common 176, playerModules 47, editor 70, player 214

🤖 Generated with [Claude Code](https://claude.com/claude-code)