### PR TITLE
Formelfeld/Formelbereich nicht mehr über den Bildschirmrand wachsen lassen (#1076)

### DIFF
--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -29,6 +29,8 @@ Editor
   - Schaltflächen zum Hinzufügen/Entfernen von Zeilen und Spalten werden nur noch im Dialog "Elemente anpassen" angezeigt (nicht mehr auf der Arbeitsfläche)
 - Assistenten
   - Korrigiert die Element-Auswahl nach dem Einfügen zweiseitiger Abschnittsvorlagen aus einem nachfolgenden Abschnitt
+- Formelfeld, Formelbereich
+  - Lange Eingaben ohne Leerzeichen vergrößern das Element auf der Arbeitsfläche nicht mehr über den Abschnittsrand hinaus (überlange Formeln scrollen innerhalb des Feldes, Segmente im Formelbereich brechen um)
 
 ## 2.12.4
 ### Fehlerbehebungen 

--- a/docs/release-notes-player.md
+++ b/docs/release-notes-player.md
@@ -18,6 +18,7 @@ Player
 ### Fehlerbehebungen
 - Formelfeld, Formelbereich
   - Behebung von Fehlern bei der Handhabung von Schreibschutz und Pflichtfeld-Markierungen
+  - Lange Eingaben ohne Leerzeichen vergrößern das Feld bzw. den Bereich nicht mehr über den Bildschirmrand hinaus; überlange Formeln scrollen innerhalb des Feldes, im Formelbereich brechen Text und Formel-Segmente in die nächste Zeile um
 
 
 ## 2.12.3

--- a/e2e/tests/e2e/math-field.spec.cy.ts
+++ b/e2e/tests/e2e/math-field.spec.cy.ts
@@ -1,5 +1,5 @@
 import {
-  addElementHover, addNewPage, addNewSection, setPreferencesElement, setCheckbox
+  addElementHover, addNewSection, setPreferencesElement, setCheckbox
 } from '../util';
 
 describe('Math-field element', { testIsolation: false }, () => {
@@ -25,26 +25,28 @@ describe('Math-field element', { testIsolation: false }, () => {
     it('creates a math-field with a preset', () => {
       addElementHover('Formel', 'Feld');
       cy.get('aspect-preset-value-properties').contains('mat-label', 'Vorbelegung')
-        .closest('aspect-preset-value-properties').find('math-field').shadow().find('.ML__content')
+        .closest('aspect-preset-value-properties').find('math-field')
+        .shadow()
+        .find('.ML__content')
         .click()
         .type('abc');
       setPreferencesElement('Formel Feld mit Vorbelegung', { id: 'math-field-preset' });
     });
 
     it('creates a math-field with an union and overline formel preset', () => {
-      const formula ="\\overline{S \\cup M}";
       addNewSection();
       addElementHover('Formel', 'Feld');
       setCheckbox('Eingabemodus änderbar');
       cy.get('aspect-element-properties').contains('mat-button-toggle', 'Formel')
         .click();
       cy.get('aspect-element-properties').contains('mat-label', 'Vorbelegung')
-        .closest('aspect-preset-value-properties').find('math-field').shadow().find('.ML__content')
+        .closest('aspect-preset-value-properties').find('math-field')
+        .shadow()
+        .find('.ML__content')
         .click()
         .type('\\overline{{}S\\cup M{}}{enter}');
       setPreferencesElement('Formel Feld mit Union Vorbelegung', { id: 'field-preset-union' });
     });
-
 
     after('saves an unit definition', () => {
       cy.saveUnit('e2e/downloads/math-field.json');
@@ -59,7 +61,8 @@ describe('Math-field element', { testIsolation: false }, () => {
 
     it('checks the common math-field is editable ', () => {
       cy.contains('aspect-element-group-selection', 'Standard Formel Feld').within(() => {
-        cy.get('math-field').shadow().find('.ML__content').click().type('1+x=2');
+        cy.get('math-field').shadow().find('.ML__content').click()
+          .type('1+x=2');
         cy.get('math-field').shadow().find('.ML__base').should('contain', '1');
         cy.get('math-field').shadow().find('.ML__base').should('contain', '+');
         cy.get('math-field').shadow().find('.ML__base').should('contain', '2');
@@ -69,7 +72,8 @@ describe('Math-field element', { testIsolation: false }, () => {
 
     it('checks that the readonly math-field can not be edited', () => {
       cy.contains('aspect-element-group-selection', 'Formel Feld mit Schreibschutz').within(() => {
-        cy.get('math-field').shadow().find('.ML__content').click().type('x+y=4');
+        cy.get('math-field').shadow().find('.ML__content').click()
+          .type('x+y=4');
         cy.get('math-field').shadow().find('.ML__base').should('not.contain', 'x');
         cy.get('math-field').shadow().find('.ML__base').should('not.contain', '+');
         cy.get('math-field').shadow().find('.ML__base').should('not.contain', 'y');
@@ -103,6 +107,24 @@ describe('Math-field element', { testIsolation: false }, () => {
         cy.get('math-field').shadow().find('.ML__content').click();
       });
       cy.get('.math-keyboard-container').should('exist');
+      cy.clickOutside();
+    });
+
+    it('checks that the math-field keeps its width and scrolls internally on long unbroken input (#1076)', () => {
+      cy.contains('aspect-element-group-selection', 'Standard Formel Feld').find('math-field').then($mathField => {
+        const initialWidth = $mathField[0].getBoundingClientRect().width;
+        cy.wrap($mathField).shadow().find('.ML__content').click()
+          .type('abcdefghijklmnopqrstuvwxyz'.repeat(3));
+        cy.wrap($mathField).should($el => {
+          const rect = $el[0].getBoundingClientRect();
+          const viewportWidth = $el[0].ownerDocument.documentElement.clientWidth;
+          expect(rect.width).to.be.at.most(initialWidth + 1);
+          expect(rect.right).to.be.at.most(viewportWidth);
+        });
+        cy.wrap($mathField).shadow().find('.ML__content').should($content => {
+          expect($content[0].scrollWidth).to.be.greaterThan($content[0].clientWidth);
+        });
+      });
       cy.clickOutside();
     });
   });

--- a/e2e/tests/e2e/text-area-math.spec.cy.ts
+++ b/e2e/tests/e2e/text-area-math.spec.cy.ts
@@ -1,4 +1,4 @@
-import {addElementHover, setPreferencesElement} from '../util';
+import { addElementHover, setPreferencesElement } from '../util';
 
 describe('Text area math element', { testIsolation: false }, () => {
   context('editor', () => {
@@ -33,8 +33,9 @@ describe('Text area math element', { testIsolation: false }, () => {
 
     it('checks the text-area-math is editable', () => {
       cy.contains('aspect-element-group-selection', 'Standard Formel Bereich').within(() => {
-        cy.get('button:contains("Formel einfügen")').click({force: true});
-        cy.get('math-field').shadow().find('.ML__content').click().type('1+x=2');
+        cy.get('button:contains("Formel einfügen")').click({ force: true });
+        cy.get('math-field').shadow().find('.ML__content').click()
+          .type('1+x=2');
         cy.get('math-field').shadow().find('.ML__base').should('contain', '1');
         cy.get('math-field').shadow().find('.ML__base').should('contain', '+');
         cy.get('math-field').shadow().find('.ML__base').should('contain', '2');
@@ -43,8 +44,9 @@ describe('Text area math element', { testIsolation: false }, () => {
 
     it('checks that the readonly text-area-math can not be edited', () => {
       cy.contains('aspect-element-group-selection', 'Formel Bereich mit Schreibschutz').within(() => {
-        cy.get('button:contains("Formel einfügen")').click({force: true});
-        cy.get('math-field').shadow().find('.ML__content').click().type('x+y=4');
+        cy.get('button:contains("Formel einfügen")').click({ force: true });
+        cy.get('math-field').shadow().find('.ML__content').click()
+          .type('x+y=4');
         cy.get('math-field').shadow().find('.ML__base').should('not.contain', 'x');
         cy.get('math-field').shadow().find('.ML__base').should('not.contain', '+');
         cy.get('math-field').shadow().find('.ML__base').should('not.contain', 'y');
@@ -55,7 +57,36 @@ describe('Text area math element', { testIsolation: false }, () => {
       cy.contains('aspect-element-group-selection', 'Formel Bereich mit Pflichtfeld').click();
       cy.clickOutside();
       cy.contains('aspect-element-group-selection',
-        'Formel Bereich mit Pflichtfeld').find('mat-error').should('exist');
+                  'Formel Bereich mit Pflichtfeld').find('mat-error').should('exist');
+    });
+
+    it('checks that long unbroken text wraps inside the text area without horizontal overflow (#1076)', () => {
+      cy.contains('aspect-element-group-selection', 'Standard Formel Bereich').within(() => {
+        cy.get('.text-area').click();
+        cy.focused().type('buchstabenketteohneleerzeichen'.repeat(4));
+        cy.get('.text-area').should($area => {
+          const viewportWidth = $area[0].ownerDocument.documentElement.clientWidth;
+          expect($area[0].scrollWidth).to.be.at.most($area[0].clientWidth);
+          expect($area[0].getBoundingClientRect().right).to.be.at.most(viewportWidth);
+        });
+      });
+      cy.clickOutside();
+    });
+
+    it('checks that formula segments are capped at the area width and scroll internally (#1076)', () => {
+      cy.contains('aspect-element-group-selection', 'Standard Formel Bereich').within(() => {
+        cy.get('math-field').shadow().find('.ML__content').click()
+          .type('abcdefghijklmnopqrstuvwxyz'.repeat(3));
+        cy.get('.text-area').then($area => {
+          cy.get('math-field').should($mathField => {
+            expect($mathField[0].getBoundingClientRect().width).to.be.at.most($area[0].clientWidth);
+          });
+        });
+        cy.get('math-field').shadow().find('.ML__content').should($content => {
+          expect($content[0].scrollWidth).to.be.greaterThan($content[0].clientWidth);
+        });
+      });
+      cy.clickOutside();
     });
   });
 });

--- a/projects/common/components/input-elements/area-text-input/area-text-input.component.scss
+++ b/projects/common/components/input-elements/area-text-input/area-text-input.component.scss
@@ -1,6 +1,8 @@
 .input {
   padding: 0 14px;
   outline: none;
-  white-space: pre;
+  // pre-wrap statt pre: Leerzeichen bleiben (contenteditable) erhalten,
+  // aber Text-Segmente dürfen umbrechen (#1076)
+  white-space: pre-wrap;
   vertical-align: text-bottom;
 }

--- a/projects/common/components/input-elements/math-field/math-field.component.scss
+++ b/projects/common/components/input-elements/math-field/math-field.component.scss
@@ -1,3 +1,10 @@
+:host {
+  // Blockifizieren + Containment: Die intrinsische Breite des einzeiligen
+  // MathLive-Inhalts darf die Grid-Spalten der Section nicht aufweiten (#1076).
+  display: block;
+  contain: inline-size;
+}
+
 .error-message {
   font-size: 75%;
   margin-top: 15px;

--- a/projects/common/components/input-elements/text-area-math/text-area-math.component.scss
+++ b/projects/common/components/input-elements/text-area-math/text-area-math.component.scss
@@ -1,5 +1,8 @@
 :host {
   display: block;
+  // Die intrinsische Breite der nicht umbrechbaren Formel-Segmente darf die
+  // Grid-Spalten der Section nicht aufweiten (#1076).
+  contain: inline-size;
 }
 
 .label {
@@ -19,6 +22,8 @@
   border: 1px solid black;
   border-radius: 3px;
   padding: 10px 5px;
+  // Buchstabenketten ohne Leerzeichen in Text-Segmenten umbrechen (#1076)
+  overflow-wrap: anywhere;
 }
 
 .insert-formula-button {

--- a/projects/common/math-editor/math-input.component.ts
+++ b/projects/common/math-editor/math-input.component.ts
@@ -42,6 +42,14 @@ import { MathKeyboardPreset } from 'common/interfaces';
 
     .inline-block{
       display: inline-block;
+      /* Formel-Segmente nie breiter als der umgebende Bereich werden lassen;
+         überlange Formeln scrollen dann intern (#1076) */
+      max-width: 100%;
+    }
+
+    :host ::ng-deep math-field {
+      max-width: 100%;
+      box-sizing: border-box;
     }
 
     :host ::ng-deep  math-field::part(virtual-keyboard-toggle) {


### PR DESCRIPTION
Closes #1076

## Problem
Lange Buchstabenketten ohne Leerzeichen ließen Formelfeld und Formelbereich nach rechts über den Bildschirmrand wachsen. Ursache: MathLive rendert Formelinhalt einzeilig und nicht umbrechbar; diese intrinsische Breite weitete die Grid-Spalten der Section auf (Min-Content-Blowout). In den Text-Segmenten des Formelbereichs verhinderte zusätzlich `white-space: pre` jeden Zeilenumbruch – auch an Leerzeichen.

## Lösung
Die Breitenkette wird am Element gekappt, das Section-Layout bleibt unangetastet (kein Risiko für andere Elementtypen):

- `display: block` + `contain: inline-size` auf den Hosts von `aspect-math-field` und `aspect-text-area-math` – die Grid-Spalte wächst nicht mehr mit dem Inhalt mit
- `max-width: 100%` (+ `box-sizing: border-box`) auf dem `math-field` und seinem Inline-Wrapper – überlange Formeln scrollen intern horizontal, der Cursor bleibt sichtbar
- Formel-Segmente im Formelbereich brechen als Ganzes in die nächste Zeile um (natives Inline-Layout, sobald eine Breitengrenze existiert)
- `white-space: pre-wrap` statt `pre` in den Text-Segmenten (Leerzeichen bleiben erhalten, Umbruch wieder möglich) + `overflow-wrap: anywhere` für Ketten ohne Leerzeichen

## Verifikation
- Playwright-gestützt am laufenden Player: Sections bleiben bei Seitenbreite (vorher 1110px bei `maxWidth` 750), nichts ragt über den Viewport, `autoColumnSize`-Sections kollabieren nicht, MathLive scrollt intern bis zum Caret
- Drei neue Cypress-E2E-Regressionstests in `math-field.spec.cy.ts` und `text-area-math.spec.cy.ts` (Feldbreite bleibt konstant + internes Scrollen; Text-Segmente brechen ohne horizontalen Overflow um; Formel-Segmente werden bei Bereichsbreite gedeckelt)
- Editor nutzt dieselben Common-Komponenten und ist mit abgedeckt
- Lint sauber, alle Common-Unit-Tests grün, beide E2E-Specs vollständig grün (20/20)
- Visuelle Sichtung durch JHo

🤖 Generated with [Claude Code](https://claude.com/claude-code)