### PR TITLE
Tooltip-Text einfache Formatierung erlauben (#1068)

### DIFF
--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -9,6 +9,9 @@ Editor
 - Tabelle
   - Neue optionale Kopfzeile: je Spalte ein Text mit einstellbarer Ausrichtung (linksbündig, zentriert, rechtsbündig); Bearbeitung im Dialog "Elemente anpassen", dort können auch weitere Kopfzeilen hinzugefügt und entfernt werden
   - Neue Eigenschaft "Haftende Kopfzeile" (fixiert die Kopfzeile beim Scrollen)
+- Tooltip (Text und Knopf)
+  - Der Tooltip-Text kann jetzt formatiert werden (Fett, Kursiv, Unterstrichen, Hoch-/Tiefstellung, Schrift- und Hintergrundfarbe, Sonderzeichen); der Dialog enthält dafür den reduzierten Texteditor
+  - Der Tooltip eines Knopfes wird über die neue Schaltfläche "Tooltip bearbeiten" im Eigenschaftenbereich im selben Dialog bearbeitet (Text, Position und Löschen)
 
 ### Änderungen
 - Formelfeld

--- a/docs/release-notes-player.md
+++ b/docs/release-notes-player.md
@@ -8,6 +8,8 @@ Player
   - Die im Editor eingestellte Textausrichtung (linksbündig, zentriert, rechtsbündig) wird bei der Eingabe dargestellt
 - Tabelle
   - Stellt die im Editor konfigurierte Kopfzeile (auch mehrzeilig) dar; optional bleibt sie beim Scrollen am oberen Rand des sichtbaren Bereichs fixiert
+- Tooltip (Text und Knopf)
+  - Stellt die im Editor eingestellte Formatierung des Tooltip-Textes dar
 
 ### Änderungen
 - Eingabehilfe/Tastatur

--- a/docs/unit_definition_changelog.txt
+++ b/docs/unit_definition_changelog.txt
@@ -250,3 +250,5 @@ iqb-aspect-definition@1.0.0
   - new property: headerEnabled: boolean
   - new property: headerRows: { text: string; alignment: 'left' | 'center' | 'right' }[][]
   - new property: stickyHeader: boolean
+- ButtonElement and tooltip mark in text elements:
+  - tooltipText (data-tooltip-text) may now contain HTML markup (formatted tooltip text)

--- a/e2e/tests/e2e/button.spec.cy.ts
+++ b/e2e/tests/e2e/button.spec.cy.ts
@@ -59,19 +59,40 @@ describe('Button element', { testIsolation: false }, () => {
       .clear()
       .type('Knopf mit Tooltip');
 
-    // Set tooltip text in properties panel
-    cy.contains('mat-form-field', 'Tooltip-Text')
-      .find('input')
-      .clear()
+    // Open the tooltip dialog from the properties panel
+    cy.contains('button', 'Tooltip bearbeiten')
+      .click();
+
+    // Set tooltip text in the rich text editor of the dialog
+    cy.get('aspect-tooltip-properties-dialog .ProseMirror')
+      .should('be.visible')
       .type('Das ist ein Button-Tooltip');
 
+    // Select the entire text programmatically using TipTap API and format it bold
+    cy.get('aspect-tooltip-properties-dialog aspect-rich-text-editor').then($el => {
+      const win = $el[0].ownerDocument.defaultView as any;
+      const component = win.ng.getComponent($el[0]);
+      component.editor.commands.selectAll();
+    });
+    cy.get('aspect-tooltip-properties-dialog')
+      .find('mat-icon:contains("format_bold")')
+      .parent()
+      .click();
+
     // Set tooltip position to "above" (oberhalb)
-    cy.contains('mat-form-field', 'Tooltip-Position')
+    cy.get('aspect-tooltip-properties-dialog')
+      .contains('mat-form-field', 'Tooltip-Position')
       .find('mat-select')
       .click();
     cy.get('.cdk-overlay-container')
       .contains('mat-option', 'oberhalb')
       .click({ force: true });
+
+    // Save the tooltip dialog
+    cy.get('aspect-tooltip-properties-dialog')
+      .contains('button', 'Speichern')
+      .click();
+    cy.get('aspect-tooltip-properties-dialog').should('not.exist');
   });
 
   it('saves unit definition', () => {
@@ -131,10 +152,12 @@ describe('Button element', { testIsolation: false }, () => {
       .find('button')
       .trigger('pointerenter');
 
-    // Assert tooltip is displayed with correct content
+    // Assert tooltip is displayed with correct content and formatting
     cy.get('aspect-tooltip')
       .should('exist')
       .and('contain.text', 'Das ist ein Button-Tooltip');
+    cy.get('aspect-tooltip strong')
+      .should('contain.text', 'Das ist ein Button-Tooltip');
 
     // Trigger mouseleave on button to hide tooltip immediately
     cy.contains('aspect-button', 'Knopf mit Tooltip')

--- a/e2e/tests/e2e/text.spec.cy.ts
+++ b/e2e/tests/e2e/text.spec.cy.ts
@@ -131,9 +131,8 @@ describe('Text element', { testIsolation: false }, () => {
                 .click();
 
             // Within the tooltip properties dialog, configure text and position
-            cy.get('aspect-tooltip-properties-dialog')
-                .contains('mat-form-field', 'Tooltip-Text')
-                .find('input')
+            cy.get('aspect-tooltip-properties-dialog .ProseMirror')
+                .should('be.visible')
                 .type('Das ist ein Text-Tooltip');
 
             cy.get('aspect-tooltip-properties-dialog')

--- a/projects/common/components/tooltip/tooltip.component.scss
+++ b/projects/common/components/tooltip/tooltip.component.scss
@@ -26,5 +26,8 @@
     color: #fff;
     font-size: 18px;
     width: fit-content;
+    ::ng-deep p {
+      margin: 0;
+    }
   }
 }

--- a/projects/common/components/tooltip/tooltip.component.spec.ts
+++ b/projects/common/components/tooltip/tooltip.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SafeResourceHTMLPipe } from 'common/pipes/safe-resource-html.pipe';
+import { TooltipComponent } from './tooltip.component';
+
+describe('TooltipComponent', () => {
+  let component: TooltipComponent;
+  let fixture: ComponentFixture<TooltipComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TooltipComponent, SafeResourceHTMLPipe]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TooltipComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render plain text tooltips', () => {
+    component.tooltipText = 'some text';
+    fixture.detectChanges();
+    const tooltipText = fixture.nativeElement.querySelector('.tooltip-text');
+    expect(tooltipText.textContent).toContain('some text');
+  });
+
+  it('should render formatted tooltip markup', () => {
+    component.tooltipText = '<p>some <strong>bold</strong> text</p>';
+    fixture.detectChanges();
+    const tooltipText = fixture.nativeElement.querySelector('.tooltip-text');
+    expect(tooltipText.querySelector('strong')?.textContent).toBe('bold');
+    expect(tooltipText.textContent).toContain('some bold text');
+  });
+});

--- a/projects/common/components/tooltip/tooltip.component.ts
+++ b/projects/common/components/tooltip/tooltip.component.ts
@@ -2,21 +2,21 @@ import { Component, ElementRef, ViewChild } from '@angular/core';
 import { TooltipPosition } from 'common/interfaces';
 
 @Component({
-    selector: 'aspect-tooltip',
-    template: `
+  selector: 'aspect-tooltip',
+  template: `
     <div #tooltip
          class="tooltip"
          [style.left.px]="left"
          [style.top.px]="top"
          [style.max-width]="maxWidth">
       <div #tooltipInner
-           class="tooltip-text">
-        {{tooltipText}}
+           class="tooltip-text"
+           [innerHTML]="tooltipText | safeResourceHTML">
       </div>
     </div>
   `,
-    styleUrls: ['./tooltip.component.scss'],
-    standalone: false
+  styleUrls: ['./tooltip.component.scss'],
+  standalone: false
 })
 export class TooltipComponent {
   tooltipText: string = '';

--- a/projects/common/pipes/has-text-content.pipe.spec.ts
+++ b/projects/common/pipes/has-text-content.pipe.spec.ts
@@ -1,0 +1,38 @@
+import { HasTextContentPipe } from './has-text-content.pipe';
+
+describe('HasTextContentPipe', () => {
+  let pipe: HasTextContentPipe;
+
+  beforeEach(() => {
+    pipe = new HasTextContentPipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return false for undefined, null and empty string', () => {
+    expect(pipe.transform(undefined)).toBe(false);
+    expect(pipe.transform(null)).toBe(false);
+    expect(pipe.transform('')).toBe(false);
+  });
+
+  it('should return false for an empty paragraph', () => {
+    expect(pipe.transform('<p></p>')).toBe(false);
+  });
+
+  it('should return false for markup containing only whitespace', () => {
+    expect(pipe.transform('<p> </p>')).toBe(false);
+    expect(pipe.transform('<p>&nbsp;</p>')).toBe(false);
+    expect(pipe.transform('<p><strong>  </strong></p>')).toBe(false);
+  });
+
+  it('should return true for plain text', () => {
+    expect(pipe.transform('some text')).toBe(true);
+  });
+
+  it('should return true for markup with text content', () => {
+    expect(pipe.transform('<p>some text</p>')).toBe(true);
+    expect(pipe.transform('<p><strong>bold</strong></p>')).toBe(true);
+  });
+});

--- a/projects/common/pipes/has-text-content.pipe.ts
+++ b/projects/common/pipes/has-text-content.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'hasTextContent',
+  standalone: false
+})
+export class HasTextContentPipe implements PipeTransform {
+  transform(html: string | undefined | null): boolean {
+    if (!html) return false;
+    return !!new DOMParser().parseFromString(html, 'text/html').body.textContent?.trim();
+  }
+}

--- a/projects/common/shared.module.ts
+++ b/projects/common/shared.module.ts
@@ -110,6 +110,7 @@ import { TableChildOverlay } from './components/compound-elements/table/table-ch
 import { MeasurePipe } from './pipes/measure.pipe';
 import { TableGridRowsPipe } from './pipes/table-grid-rows.pipe';
 import { MarkingPanelComponent } from './components/text/marking-panel.component';
+import { HasTextContentPipe } from './pipes/has-text-content.pipe';
 
 @NgModule({
   declarations: [
@@ -176,7 +177,8 @@ import { MarkingPanelComponent } from './components/text/marking-panel.component
     TableChildOverlay,
     MarkingPanelComponent,
     MeasurePipe,
-    TableGridRowsPipe
+    TableGridRowsPipe,
+    HasTextContentPipe
   ],
   exports: [
     CommonModule,
@@ -192,6 +194,7 @@ import { MarkingPanelComponent } from './components/text/marking-panel.component
     MatDialogModule,
     TranslateModule,
     SafeResourceHTMLPipe,
+    HasTextContentPipe,
     ScrollPagesPipe,
     TextMarkingBarComponent,
     ToggleButtonComponent,

--- a/projects/editor/src/app/components/dialogs/tooltip-properties-dialog.component.spec.ts
+++ b/projects/editor/src/app/components/dialogs/tooltip-properties-dialog.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule } from '@ngx-translate/core';
+import { HasTextContentPipe } from 'common/pipes/has-text-content.pipe';
+import { DialogService } from 'editor/src/app/services/dialog.service';
+import { RichTextEditorComponent } from 'editor/src/app/text-editor/rich-text-editor.component';
+import { TooltipPropertiesDialogComponent } from './tooltip-properties-dialog.component';
+
+describe('TooltipPropertiesDialogComponent', () => {
+  let component: TooltipPropertiesDialogComponent;
+  let fixture: ComponentFixture<TooltipPropertiesDialogComponent>;
+
+  const configureTestBed = async (
+    dialogData: { tooltipText: string | undefined, tooltipPosition: string | undefined }
+  ): Promise<void> => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        TooltipPropertiesDialogComponent,
+        HasTextContentPipe
+      ],
+      imports: [
+        CommonModule,
+        MatDialogModule,
+        FormsModule,
+        MatFormFieldModule,
+        MatSelectModule,
+        MatButtonModule,
+        RichTextEditorComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: DialogService, useValue: {} }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TooltipPropertiesDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  const getSaveButton = (): HTMLButtonElement | null => Array
+    .from(fixture.nativeElement.querySelectorAll('mat-dialog-actions button') as NodeListOf<HTMLButtonElement>)
+    .find(button => button.textContent?.includes('save')) || null;
+
+  describe('with a new tooltip', () => {
+    beforeEach(async () => {
+      await configureTestBed({ tooltipText: undefined, tooltipPosition: undefined });
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should initialize with defaults and without delete button', () => {
+      expect(component.tooltipText).toBe('');
+      expect(component.tooltipPosition).toBe('below');
+      expect(component.newTooltip).toBe(true);
+      const buttons = fixture.nativeElement.querySelectorAll('mat-dialog-actions button');
+      expect(buttons.length).toBe(2);
+    });
+
+    it('should disable save button while tooltip text is empty', () => {
+      expect(getSaveButton()?.disabled).toBe(true);
+    });
+
+    it('should keep save button disabled for an empty paragraph', () => {
+      component.tooltipText = '<p></p>';
+      fixture.detectChanges();
+      expect(getSaveButton()?.disabled).toBe(true);
+    });
+
+    it('should enable save button for formatted tooltip text', () => {
+      component.tooltipText = '<p><strong>some text</strong></p>';
+      fixture.detectChanges();
+      expect(getSaveButton()?.disabled).toBe(false);
+    });
+  });
+
+  describe('with an existing tooltip', () => {
+    beforeEach(async () => {
+      await configureTestBed({ tooltipText: 'some text', tooltipPosition: 'above' });
+    });
+
+    it('should initialize with given values and show delete button', () => {
+      expect(component.tooltipText).toBe('some text');
+      expect(component.tooltipPosition).toBe('above');
+      expect(component.newTooltip).toBe(false);
+      const buttons = fixture.nativeElement.querySelectorAll('mat-dialog-actions button');
+      expect(buttons.length).toBe(3);
+    });
+
+    it('should enable save button', () => {
+      expect(getSaveButton()?.disabled).toBe(false);
+    });
+  });
+});

--- a/projects/editor/src/app/components/dialogs/tooltip-properties-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/tooltip-properties-dialog.component.ts
@@ -3,41 +3,47 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TooltipPosition } from 'common/interfaces';
 
 @Component({
-    selector: 'aspect-tooltip-properties-dialog',
-    template: `
+  selector: 'aspect-tooltip-properties-dialog',
+  template: `
+    <h2 mat-dialog-title>{{'propertiesPanel.tooltipText' | translate}}</h2>
     <mat-dialog-content>
       <div class="fx-column-start-stretch">
-        <mat-form-field>
-          <mat-label>{{'propertiesPanel.tooltipText' | translate}}</mat-label>
-          <input matInput
-                 [(ngModel)]="tooltipText">
-        </mat-form-field>
+        <aspect-rich-text-editor [(content)]="tooltipText"
+                                 [showReducedControls]="true"
+                                 [controlPanelFolded]="false"
+                                 [autoFocus]="true">
+        </aspect-rich-text-editor>
         <mat-form-field appearance="fill">
           <mat-label>{{'propertiesPanel.tooltipPosition' | translate }}</mat-label>
           <mat-select [(ngModel)]="tooltipPosition">
-            <mat-option *ngFor="let option of ['left', 'right', 'above', 'below']"
-                        [value]="option">
-              {{ 'propertiesPanel.' + option | translate }}
-            </mat-option>
+            @for (option of ['left', 'right', 'above', 'below']; track option) {
+              <mat-option [value]="option">
+                {{ 'propertiesPanel.' + option | translate }}
+              </mat-option>
+            }
           </mat-select>
         </mat-form-field>
       </div>
     </mat-dialog-content>
     <mat-dialog-actions>
       <button mat-button
-              [disabled]="!tooltipText"
+              [disabled]="!(tooltipText | hasTextContent)"
               [mat-dialog-close]="{ tooltipText, tooltipPosition, action: 'save' }">
         {{'save' | translate }}
       </button>
-      <button *ngIf="!newTooltip"
-              mat-button
-              [mat-dialog-close]="{ tooltipText, tooltipPosition, action: 'delete' }">
-        {{'delete' | translate }}
-      </button>
+      @if (!newTooltip) {
+        <button mat-button
+                [mat-dialog-close]="{ tooltipText, tooltipPosition, action: 'delete' }">
+          {{'delete' | translate }}
+        </button>
+      }
       <button mat-button mat-dialog-close>{{'cancel' | translate }}</button>
     </mat-dialog-actions>
   `,
-    standalone: false
+  styles: `
+    aspect-rich-text-editor {min-height: 200px; margin-bottom: 15px;}
+  `,
+  standalone: false
 })
 export class TooltipPropertiesDialogComponent {
   tooltipText: string;

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/button-properties.component.spec.ts
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/button-properties.component.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { UIElement } from 'common/models/elements/element';
+import { createSpyObj, SpyObj } from 'common/util/vitest-spy-object';
+import { DialogService } from 'editor/src/app/services/dialog.service';
+import { ButtonPropertiesComponent } from './button-properties.component';
+
+describe('ButtonPropertiesComponent', () => {
+  let component: ButtonPropertiesComponent;
+  let fixture: ComponentFixture<ButtonPropertiesComponent>;
+  let dialogService: SpyObj<DialogService>;
+
+  beforeEach(async () => {
+    dialogService = createSpyObj<DialogService>(['showTooltipDialog']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ButtonPropertiesComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: DialogService, useValue: dialogService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonPropertiesComponent);
+    component = fixture.componentInstance;
+    component.combinedProperties = {
+      asLink: false,
+      tooltipText: 'old text',
+      tooltipPosition: 'below'
+    } as unknown as UIElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the edit tooltip button', () => {
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>);
+    expect(buttons.some(button => button.textContent?.includes('propertiesPanel.editTooltip'))).toBe(true);
+  });
+
+  it('should emit tooltip text and position on save', () => {
+    dialogService.showTooltipDialog.mockReturnValue(
+      of({ tooltipText: '<p>new text</p>', tooltipPosition: 'above', action: 'save' })
+    );
+    const emitted: { property: string; value: unknown }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    component.editTooltip();
+
+    expect(dialogService.showTooltipDialog).toHaveBeenCalledWith('old text', 'below');
+    expect(emitted).toEqual([
+      { property: 'tooltipText', value: '<p>new text</p>' },
+      { property: 'tooltipPosition', value: 'above' }
+    ]);
+  });
+
+  it('should emit empty tooltip text on delete', () => {
+    dialogService.showTooltipDialog.mockReturnValue(
+      of({ tooltipText: 'old text', tooltipPosition: 'below', action: 'delete' })
+    );
+    const emitted: { property: string; value: unknown }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    component.editTooltip();
+
+    expect(emitted).toEqual([{ property: 'tooltipText', value: '' }]);
+  });
+
+  it('should not emit anything when the dialog is cancelled', () => {
+    dialogService.showTooltipDialog.mockReturnValue(of(undefined as never));
+    const emitted: { property: string; value: unknown }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    component.editTooltip();
+
+    expect(emitted).toEqual([]);
+  });
+
+  it('should pass undefined instead of an empty tooltip text to the dialog', () => {
+    dialogService.showTooltipDialog.mockReturnValue(of(undefined as never));
+    component.combinedProperties = {
+      asLink: false, tooltipText: '', tooltipPosition: 'below'
+    } as unknown as UIElement;
+
+    component.editTooltip();
+
+    expect(dialogService.showTooltipDialog).toHaveBeenCalledWith(undefined, 'below');
+  });
+});

--- a/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/button-properties.component.ts
+++ b/projects/editor/src/app/components/properties-panel/model-properties-tab/input-groups/ele-specific/button-properties.component.ts
@@ -1,31 +1,25 @@
 import {
-  Component, EventEmitter, Input, Output
+  Component, EventEmitter, Input, OnDestroy, Output
 } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { UIElement } from 'common/models/elements/element';
+import { TooltipPosition } from 'common/interfaces';
 import { TranslateModule } from '@ngx-translate/core';
-import { NgForOf, NgIf } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { MatInputModule } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
 import { DialogService } from 'editor/src/app/services/dialog.service';
 
 @Component({
-    selector: 'aspect-button-properties',
-    imports: [
-        NgIf,
-        NgForOf,
-        TranslateModule,
-        MatButtonModule,
-        MatCheckboxModule,
-        MatFormFieldModule,
-        MatSelectModule,
-        MatInputModule,
-        FormsModule
-    ],
-    template: `
+  selector: 'aspect-button-properties',
+  imports: [
+    NgIf,
+    TranslateModule,
+    MatButtonModule,
+    MatCheckboxModule
+  ],
+  template: `
     <ng-container *ngIf="combinedProperties.asLink !== undefined">
       <fieldset>
         <legend>{{ 'propertiesPanel.presentation' | translate }}</legend>
@@ -87,27 +81,17 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
       <fieldset>
         <legend>{{ 'propertiesPanel.tooltip' | translate }}</legend>
         <div class="fx-column-start-stretch">
-          <mat-form-field *ngIf="combinedProperties.tooltipText !== undefined">
-            <mat-label>{{ 'propertiesPanel.tooltipText' | translate }}</mat-label>
-            <input matInput
-                   [ngModel]="combinedProperties.tooltipText"
-                   (ngModelChange)="updateModel.emit({ property: 'tooltipText', value: $event })">
-          </mat-form-field>
-          <mat-form-field *ngIf="combinedProperties.tooltipPosition !== undefined" appearance="fill">
-            <mat-label>{{ 'propertiesPanel.tooltipPosition' | translate }}</mat-label>
-            <mat-select [value]="combinedProperties.tooltipPosition"
-                        (selectionChange)="updateModel.emit({ property: 'tooltipPosition', value: $event.value })">
-              <mat-option *ngFor="let option of ['left', 'right', 'above', 'below']"
-                          [value]="option">
-                {{ 'propertiesPanel.' + option | translate }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
+          @if (combinedProperties.tooltipText !== undefined) {
+            <button mat-raised-button
+                    (click)="editTooltip()">
+              {{ 'propertiesPanel.editTooltip' | translate }}
+            </button>
+          }
         </div>
       </fieldset>
     </ng-container>
   `,
-    styles: [`
+  styles: [`
     .checked {
       background-color: #ccc;
     }
@@ -122,7 +106,7 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
     }
   `]
 })
-export class ButtonPropertiesComponent {
+export class ButtonPropertiesComponent implements OnDestroy {
   @Input() combinedProperties!: UIElement;
   @Output() updateModel =
     new EventEmitter<{
@@ -130,6 +114,8 @@ export class ButtonPropertiesComponent {
     }>();
 
   checked = false;
+
+  private ngUnsubscribe = new Subject<void>();
 
   constructor(private dialogService: DialogService) { }
 
@@ -142,5 +128,28 @@ export class ButtonPropertiesComponent {
 
   removeImage(): void {
     this.updateModel.emit({ property: 'imageSrc', value: null });
+  }
+
+  editTooltip(): void {
+    this.dialogService.showTooltipDialog(
+      (this.combinedProperties.tooltipText as string) || undefined,
+      this.combinedProperties.tooltipPosition as TooltipPosition
+    )
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(result => {
+        if (result) {
+          if (result.action === 'delete') {
+            this.updateModel.emit({ property: 'tooltipText', value: '' });
+          } else {
+            this.updateModel.emit({ property: 'tooltipText', value: result.tooltipText });
+            this.updateModel.emit({ property: 'tooltipPosition', value: result.tooltipPosition });
+          }
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
   }
 }

--- a/projects/editor/src/app/services/dialog.service.ts
+++ b/projects/editor/src/app/services/dialog.service.ts
@@ -227,7 +227,7 @@ export class DialogService {
   ): Observable<{ tooltipText: string, tooltipPosition: TooltipPosition, action: 'save' | 'delete' }> {
     const dialogRef = this.dialog.open(TooltipPropertiesDialogComponent, {
       data: { tooltipText, tooltipPosition },
-      width: '500px',
+      width: '750px',
       autoFocus: false
     });
     return dialogRef.afterClosed();

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -114,6 +114,7 @@
     "margin": "Abstand",
     "tooltipText": "Tooltip-Text",
     "tooltipPosition": "Tooltip-Position",
+    "editTooltip": "Tooltip bearbeiten",
     "top": "oben",
     "left": "links",
     "above": "oberhalb",


### PR DESCRIPTION
Closes #1068

## Änderungen

**Editor**
- Der Tooltip-Dialog (`TooltipPropertiesDialogComponent`) enthält statt des einfachen Textfelds jetzt den reduzierten Rich-Text-Editor (`showReducedControls`, ausgeklappte Toolbar, Autofokus); Dialogbreite auf 750px erhöht
- Button-Element: Tooltip-Text und -Position werden im Eigenschaftenbereich über die neue Schaltfläche „Tooltip bearbeiten" im selben Dialog bearbeitet (inkl. Löschen); die bisherigen Einzelfelder entfallen
- Neuer i18n-Key `propertiesPanel.editTooltip`

**Common/Player**
- `TooltipComponent` rendert den Text jetzt als HTML (`safeResourceHTML`); `p`-Margins im Tooltip zurückgesetzt — bestehende Klartext-Tooltips werden unverändert dargestellt
- Neue Pipe `hasTextContent`: erkennt inhaltlich leeres Rich-Text-Markup (z. B. `<p></p>`) und verhindert als Speichern-Guard im Dialog, dass leere Tooltips gespeichert werden (bestehende `!tooltipText`-Prüfungen bleiben dadurch funktionsfähig)

**Doku**
- Release-Notes (Editor + Player) und `unit_definition_changelog.txt` (4.12.0) ergänzt

## Tests
- Neue Specs: `hasTextContent`-Pipe, `TooltipComponent`, `TooltipPropertiesDialogComponent`, `ButtonPropertiesComponent`
- E2E angepasst: `text.spec.cy.ts` (Tooltip-Eingabe im Rich-Text-Editor), `button.spec.cy.ts` (Dialog-Flow inkl. Fettformatierung, Player prüft `<strong>`-Rendering)
- `ng test common` (185) und `ng test editor` (83) grün, beide E2E-Specs lokal grün, `ng build editor`/`player` erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)