### PR TITLE
Charakterisierungsnetz für das Properties-Panel (#1127)

### DIFF
--- a/projects/editor/src/app/components/properties-panel/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/components/properties-panel/element-properties-panel/element-properties-panel.component.spec.ts
@@ -167,6 +167,97 @@ describe('ElementPropertiesPanelComponent', () => {
     expect(combined?.idList).toBeUndefined();
   });
 
+  describe('createCombinedProperties', () => {
+    const element = (properties: Record<string, unknown>): UIElement => properties as unknown as UIElement;
+
+    it('should return undefined for an empty selection', () => {
+      expect(ElementPropertiesPanelComponent.createCombinedProperties([])).toBeUndefined();
+    });
+
+    // The merge adds two keys that the element itself does not have. Templates test for
+    // `rows === undefined` rather than for the key, so both stay compatible with that.
+    it('should add an id list and a rows key for a single element', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'text-field', id: 'a' })
+      ]);
+
+      expect(combined?.idList).toEqual(['a']);
+      expect(combined && 'rows' in combined).toBe(true);
+      expect(combined?.rows).toBeUndefined();
+    });
+
+    // The rows array is copied so that the options panel sees a new reference and re-renders.
+    it('should replace the rows array with a new reference', () => {
+      const rows = [{ id: 'r1' }];
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'likert', id: 'a', rows })
+      ]);
+
+      expect(combined?.rows).not.toBe(rows);
+      expect(combined?.rows).toEqual(rows);
+    });
+
+    it('should merge property groups recursively and null only the diverging entries', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'text-field', id: 'a', position: { xPosition: 0, yPosition: 10 } }),
+        element({ type: 'text-field', id: 'b', position: { xPosition: 5, yPosition: 10 } })
+      ]);
+
+      expect(combined?.position).toEqual(expect.objectContaining({ xPosition: null, yPosition: 10 }));
+    });
+
+    it('should null a diverging array instead of merging it', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'dropdown', id: 'a', options: [{ text: 'one' }] }),
+        element({ type: 'dropdown', id: 'b', options: [{ text: 'two' }] })
+      ]);
+
+      expect(combined?.options).toBeNull();
+    });
+
+    it('should keep an array whose contents are equal', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'dropdown', id: 'a', options: [{ text: 'one' }] }),
+        element({ type: 'dropdown', id: 'b', options: [{ text: 'one' }] })
+      ]);
+
+      expect(combined?.options).toEqual([{ text: 'one' }]);
+    });
+
+    it('should null diverging primitives of any type', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({
+          type: 'text-field', id: 'a', readOnly: false, rowCount: 2, label: 'first'
+        }),
+        element({
+          type: 'text-field', id: 'b', readOnly: true, rowCount: 3, label: 'second'
+        })
+      ]);
+
+      expect(combined?.readOnly).toBeNull();
+      expect(combined?.rowCount).toBeNull();
+      expect(combined?.label).toBeNull();
+    });
+
+    it('should keep the shared type when merging elements of the same type', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'checkbox', id: 'a' }),
+        element({ type: 'checkbox', id: 'b' })
+      ]);
+
+      expect(combined?.type).toBe('checkbox');
+    });
+
+    it('should null the type when merging elements of different types', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'checkbox', id: 'a' }),
+        element({ type: 'dropdown', id: 'b' })
+      ]);
+
+      expect(combined?.type).toBeNull();
+    });
+  });
+
   it('should update the elements property for valid input', () => {
     selectedElements.next([buttonElement]);
     fixture.detectChanges();

--- a/projects/editor/src/app/components/properties-panel/properties-panel.baseline.ts
+++ b/projects/editor/src/app/components/properties-panel/properties-panel.baseline.ts
@@ -1,0 +1,1655 @@
+/**
+ * Generated baseline for `properties-panel.characterization.spec.ts` — one entry per
+ * (element type, expert mode), holding the controls the panel renders as readable text.
+ *
+ * Do NOT hand-edit to make a failing test pass. A diff here means the panel now shows
+ * something different; either that change is intended (then regenerate and review the diff
+ * as part of the change) or it is a regression.
+ *
+ * Regenerate: un-skip the `baseline regeneration` block in
+ * `properties-panel.characterization.spec.ts`, run
+ * `npx ng test editor --include "**\/properties-panel.characterization.spec.ts"`, and replace
+ * everything below this comment with the logged block.
+ *
+ * The vitest snapshot mechanism cannot be used here: the `@angular/build:unit-test` builder
+ * compiles specs into a fresh `dist/test-out/<timestamp>/` directory, so `.snap` files never
+ * persist between runs and could never fail.
+ */
+/* eslint-disable max-len */
+export const PANEL_BASELINE: Record<string, string> = {
+  'audio|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = audio
+button "Medienoptionen anpassen"
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 90
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = #f1f1f1
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'audio|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = audio
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'button|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = button
+textarea "propertiesPanel.label" = Knopf
+[propertiesPanel.presentation]
+button "propertiesPanel.button"
+button "propertiesPanel.image"
+button "propertiesPanel.link"
+checkbox "propertiesPanel.super" = false
+checkbox "propertiesPanel.sub" = false
+[propertiesPanel.tooltip]
+button "propertiesPanel.editTooltip"
+[propertiesPanel.action]
+select "propertiesPanel.action" = <null>
+select "propertiesPanel.actionParam" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 60
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = lightgrey
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+[Rahmen]
+input[number] "propertiesPanel.borderRadius" = 0
+input[text] "propertiesPanel.borderColor" = black
+select "propertiesPanel.borderStyle" = solid
+input[number] "propertiesPanel.borderWidth" = 0
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'button|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = button
+textarea "propertiesPanel.label" = Knopf
+[propertiesPanel.presentation]
+button "propertiesPanel.button"
+button "propertiesPanel.image"
+button "propertiesPanel.link"
+checkbox "propertiesPanel.super" = false
+checkbox "propertiesPanel.sub" = false
+[propertiesPanel.tooltip]
+button "propertiesPanel.editTooltip"
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'checkbox|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = checkbox
+[Eingabeelement]
+textarea "propertiesPanel.label" = Beschriftung
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+button "image"
+toggle-group [propertiesPanel.true, propertiesPanel.false]
+checkbox "propertiesPanel.crossOutChecked" = false
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 215
+input[number] "propertiesPanel.height" = 60
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'checkbox|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = checkbox
+[Eingabeelement]
+textarea "propertiesPanel.label" = Beschriftung
+checkbox "propertiesPanel.readOnly" = false
+button "image"
+toggle-group [propertiesPanel.true, propertiesPanel.false]
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'cloze|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = cloze
+button "Text und Elemente editieren"
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 200
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 180
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'cloze|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = cloze
+button "Text und Elemente editieren"
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'drop-list|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = drop-list
+[Eingabeelement]
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+[preset]
+textarea "Neue Option" = 
+select "propertiesPanel.connectedDropLists" = []
+select "propertiesPanel.alignment" = vertical
+checkbox "propertiesPanel.isSortList" = false
+checkbox "propertiesPanel.onlyOneItem" = false
+checkbox "allowReplacement" = false
+checkbox "propertiesPanel.copyOnDrop" = false
+checkbox "propertiesPanel.permanentPlaceholders" = false
+checkbox "propertiesPanel.permanentPlaceholdersCC" = false (disabled)
+checkbox "propertiesPanel.showNumbering" = false
+checkbox "propertiesPanel.startNumberingAtZero" = false (disabled)
+checkbox "propertiesPanel.highlightReceivingDropList" = false
+input[text] "propertiesPanel.highlightReceivingDropListColor" = #006064 (disabled)
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 240
+input[number] "propertiesPanel.height" = 100
+
+--- tab "styling" ---
+input[text] "propertiesPanel.itemBackgroundColor" = #c9e0e0
+input[text] "propertiesPanel.backgroundColor" = #ededed
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'drop-list|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = drop-list
+[Eingabeelement]
+checkbox "propertiesPanel.readOnly" = false
+[preset]
+textarea "Neue Option" = 
+select "propertiesPanel.connectedDropLists" = []
+select "propertiesPanel.alignment" = vertical
+checkbox "propertiesPanel.isWidthFixed" = false
+input[number] "propertiesPanel.width" = 240 (disabled)
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'dropdown|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = dropdown
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+checkbox "propertiesPanel.allowUnset" = false
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 240
+input[number] "propertiesPanel.height" = 83
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'dropdown|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = dropdown
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+checkbox "propertiesPanel.allowUnset" = false
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'frame|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = frame
+checkbox "propertiesPanel.hasBorderTop" = true
+checkbox "propertiesPanel.hasBorderBottom" = true
+checkbox "propertiesPanel.hasBorderLeft" = true
+checkbox "propertiesPanel.hasBorderRight" = true
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = -1
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 180
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+[Rahmen]
+input[number] "propertiesPanel.borderRadius" = 0
+input[text] "propertiesPanel.borderColor" = black
+select "propertiesPanel.borderStyle" = solid
+input[number] "propertiesPanel.borderWidth" = 1
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'frame|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = frame
+checkbox "propertiesPanel.hasBorderTop" = true
+checkbox "propertiesPanel.hasBorderBottom" = true
+checkbox "propertiesPanel.hasBorderLeft" = true
+checkbox "propertiesPanel.hasBorderRight" = true
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'geometry|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = geometry
+input[text] "propertiesPanel.appDefinition" =  (disabled)
+checkbox "propertiesPanel.showResetIcon" = true
+[propertiesPanel.geogebraHeader]
+checkbox "propertiesPanel.enableUndoRedo" = true
+checkbox "propertiesPanel.enableShiftDragZoom" = false
+checkbox "propertiesPanel.showZoomButtons" = false
+checkbox "propertiesPanel.showFullscreenButton" = false
+checkbox "propertiesPanel.showToolbar" = true
+input[text] "propertiesPanel.customToolbar" = 
+[propertiesPanel.trackedGeogebraVariables]
+select "propertiesPanel.trackedVariables" = []
+input[text] "propertiesPanel.trackedExpectedVariables" = 
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 600
+input[number] "propertiesPanel.height" = 400
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'geometry|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = geometry
+input[text] "propertiesPanel.appDefinition" =  (disabled)
+[propertiesPanel.geogebraHeader]
+[propertiesPanel.trackedGeogebraVariables]
+select "propertiesPanel.trackedVariables" = []
+input[text] "propertiesPanel.trackedExpectedVariables" = 
+input[number] "propertiesPanel.width" = 600
+input[number] "propertiesPanel.height" = 400
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'hotspot-image|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = hotspot-image
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+[propertiesPanel.hotspots]
+button "add"
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 250
+input[number] "propertiesPanel.height" = 100
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'hotspot-image|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = hotspot-image
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+[propertiesPanel.hotspots]
+button "add"
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'image|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = image
+input[text] "Alternativtext" = Bild nicht gefunden
+button "Medienoptionen anpassen"
+checkbox "propertiesPanel.scale" = false
+checkbox "propertiesPanel.magnifier" = false
+checkbox "propertiesPanel.allowFullscreen" = false
+input[number] "propertiesPanel.magnifierSize in px" = 100 (disabled)
+slider ""
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 100
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'image|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = image
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'likert-row|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = likert-row
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+input[number] "propertiesPanel.firstColumnSizeRatio" = 5
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 50
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'likert-row|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = likert-row
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+input[number] "propertiesPanel.firstColumnSizeRatio" = 5
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'likert|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = likert
+textarea "propertiesPanel.label" = Optionentabelle Beschriftung
+textarea "propertiesPanel.label2" = Beschriftung Erste Spalte
+[propertiesPanel.options]
+textarea "Neue Option" = 
+[rows]
+textarea "Neue Zeile" = 
+checkbox "propertiesPanel.stickyHeader" = false
+input[number] "propertiesPanel.firstColumnSizeRatio" = 5
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 250
+input[number] "propertiesPanel.height" = 200
+
+--- tab "styling" ---
+checkbox "propertiesPanel.lineColoring" = true
+input[text] "propertiesPanel.lineColoringColor" = #c9e0e0
+checkbox "propertiesPanel.firstLineColoring" = false
+input[text] "propertiesPanel.firstLineColoringColor" = #c7f3d0 (disabled)
+input[text] "propertiesPanel.backgroundColor" = white
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'likert|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = likert
+textarea "propertiesPanel.label" = Optionentabelle Beschriftung
+textarea "propertiesPanel.label2" = Beschriftung Erste Spalte
+[propertiesPanel.options]
+textarea "Neue Option" = 
+[rows]
+textarea "Neue Zeile" = 
+input[number] "propertiesPanel.firstColumnSizeRatio" = 5
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'marking-panel|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = marking-panel
+[propertiesPanel.marking]
+checkbox "propertiesPanel.highlightableYellow" = true
+checkbox "propertiesPanel.highlightableTurquoise" = false
+checkbox "propertiesPanel.highlightableOrange" = false
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 98
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'marking-panel|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = marking-panel
+[propertiesPanel.marking]
+checkbox "propertiesPanel.highlightableYellow" = true
+checkbox "propertiesPanel.highlightableTurquoise" = false
+checkbox "propertiesPanel.highlightableOrange" = false
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'math-field|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = math-field
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+button "code"
+checkbox "propertiesPanel.enableModeSwitch" = false
+select "formulaPreset.title" = [math, symbols, latin, greek]
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 230
+input[number] "propertiesPanel.height" = 80
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'math-field|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = math-field
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+button "code"
+checkbox "propertiesPanel.enableModeSwitch" = false
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'math-table|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = math-table
+select "Operation" = addition
+input[text] "Term" = 123
+button "clear"
+input[text] "Term" = 456
+button "clear"
+button "add addTermRow"
+input[text] "resultHelperRow" = 
+input[text] "resultRow" = 
+button "Variables Layout anpassen" (disabled)
+[Tastatur]
+checkbox "propertiesPanel.showSoftwareKeyboard" = false
+checkbox "propertiesPanel.hideNativeKeyboard" = false (disabled)
+checkbox "propertiesPanel.addInputAssistanceToKeyboard" = false (disabled)
+[Eingabehilfe]
+select "propertiesPanel.inputAssistance" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 230
+input[number] "propertiesPanel.height" = 192
+
+--- tab "styling" ---
+input[text] "propertiesPanel.helperRowColor" = transparent
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'math-table|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = math-table
+input[text] "Term" = 123
+button "clear"
+input[text] "Term" = 456
+button "clear"
+button "add addTermRow"
+input[text] "resultHelperRow" = 
+input[text] "resultRow" = 
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'radio-group-images|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = radio-group-images
+[Eingabeelement]
+textarea "propertiesPanel.label" = Beschriftung
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+checkbox "limitItemPerRow" = false
+input[number] "itemsPerRow" =  (disabled)
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 250
+input[number] "propertiesPanel.height" = 200
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'radio-group-images|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = radio-group-images
+[Eingabeelement]
+textarea "propertiesPanel.label" = Beschriftung
+checkbox "propertiesPanel.readOnly" = false
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+checkbox "limitItemPerRow" = false
+input[number] "itemsPerRow" =  (disabled)
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'radio|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = radio
+[Eingabeelement]
+textarea "propertiesPanel.label" = Beschriftung
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+select "propertiesPanel.alignment" = column
+checkbox "propertiesPanel.strikeOtherOptions" = false
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 215
+input[number] "propertiesPanel.height" = 80
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 100
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'radio|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = radio
+[Eingabeelement]
+textarea "propertiesPanel.label" = Beschriftung
+checkbox "propertiesPanel.readOnly" = false
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+select "propertiesPanel.alignment" = column
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'slider|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = slider
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+input[number] "propertiesPanel.minValue" = 0
+input[number] "propertiesPanel.maxValue" = 100
+checkbox "propertiesPanel.showValues" = true
+checkbox "propertiesPanel.barStyle" = true
+checkbox "propertiesPanel.thumbLabel" = true
+input[number] "propertiesPanel.preset" = 
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 240
+input[number] "propertiesPanel.height" = 80
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 5
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'slider|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = slider
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+input[number] "propertiesPanel.minValue" = 0
+input[number] "propertiesPanel.maxValue" = 100
+input[number] "propertiesPanel.preset" = 
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'spell-correct|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = spell-correct
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+[Tastatur]
+checkbox "propertiesPanel.showSoftwareKeyboard" = false
+checkbox "propertiesPanel.hideNativeKeyboard" = false (disabled)
+checkbox "propertiesPanel.addInputAssistanceToKeyboard" = false (disabled)
+[Eingabehilfe]
+select "propertiesPanel.inputAssistance" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 230
+input[number] "propertiesPanel.height" = 80
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'spell-correct|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = spell-correct
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'table|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = table
+button "Elemente anpassen"
+[section-menu.rows]
+input[number] "section-menu.rowCount" = 2
+input[number] "section-menu.height 1" = 1
+select "Einheit" = fr
+input[number] "section-menu.height 2" = 1
+select "Einheit" = fr
+[section-menu.columns]
+input[number] "section-menu.columnCount" = 2
+input[number] "section-menu.width 1" = 1
+select "Einheit" = fr
+input[number] "section-menu.width 2" = 1
+select "Einheit" = fr
+checkbox "Tabellenränder zeichnen" = false
+checkbox "propertiesPanel.tableHeaderEnabled" = false
+checkbox "propertiesPanel.stickyHeader" = false (disabled)
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 250
+input[number] "propertiesPanel.height" = 200
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+[Rahmen]
+input[number] "propertiesPanel.borderRadius" = 0
+input[text] "propertiesPanel.borderColor" = black
+select "propertiesPanel.borderStyle" = solid
+input[number] "propertiesPanel.borderWidth" = 1
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'table|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = table
+button "Elemente anpassen"
+[section-menu.rows]
+input[number] "section-menu.rowCount" = 2
+input[number] "section-menu.height 1" = 1
+select "Einheit" = fr
+input[number] "section-menu.height 2" = 1
+select "Einheit" = fr
+[section-menu.columns]
+input[number] "section-menu.columnCount" = 2
+input[number] "section-menu.width 1" = 1
+select "Einheit" = fr
+input[number] "section-menu.width 2" = 1
+select "Einheit" = fr
+checkbox "Tabellenränder zeichnen" = false
+checkbox "propertiesPanel.tableHeaderEnabled" = false
+checkbox "propertiesPanel.stickyHeader" = false (disabled)
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'text-area-math|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-area-math
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+checkbox "propertiesPanel.hasAutoHeight" = false
+input[number] "rows" = 2
+select "formulaPreset.title" = [math, symbols, latin, greek]
+[Tastatur]
+checkbox "propertiesPanel.showSoftwareKeyboard" = false
+checkbox "propertiesPanel.hideNativeKeyboard" = false (disabled)
+checkbox "propertiesPanel.addInputAssistanceToKeyboard" = false (disabled)
+[Eingabehilfe]
+select "propertiesPanel.inputAssistance" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 230
+input[number] "propertiesPanel.height" = 132
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'text-area-math|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-area-math
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+input[number] "rows" = 2
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'text-area|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-area
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+textarea "preset" = 
+checkbox "propertiesPanel.resizeEnabled" = false
+checkbox "propertiesPanel.hasAutoHeight" = false (disabled)
+checkbox "propertiesPanel.hasDynamicRowCount" = true
+input[number] "propertiesPanel.expectedCharactersCount" = 135
+[propertiesPanel.textAlign]
+toggle-group [format_align_left, format_align_center, format_align_right]
+select "propertiesPanel.appearance" = outline
+[Tastatur]
+checkbox "propertiesPanel.showSoftwareKeyboard" = false
+checkbox "propertiesPanel.hideNativeKeyboard" = false (disabled)
+checkbox "propertiesPanel.addInputAssistanceToKeyboard" = false (disabled)
+[Eingabehilfe]
+select "propertiesPanel.inputAssistance" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 230
+input[number] "propertiesPanel.height" = 132
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'text-area|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-area
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+textarea "preset" = 
+checkbox "propertiesPanel.hasDynamicRowCount" = true
+input[number] "propertiesPanel.expectedCharactersCount" = 135
+[propertiesPanel.textAlign]
+toggle-group [format_align_left, format_align_center, format_align_right]
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'text-field-simple|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-field-simple
+[Eingabeelement]
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+input[text] "preset" = 
+[propertiesPanel.textAlign]
+toggle-group [format_align_left, format_align_center, format_align_right]
+input[number] "propertiesPanel.minLength" = 
+input[text] "propertiesPanel.minLengthWarnMessage" = Eingabe zu kurz (disabled)
+input[number] "propertiesPanel.maxLength" = 
+checkbox "propertiesPanel.isLimitedToMaxLength" = true (disabled)
+input[text] "propertiesPanel.maxLengthWarnMessage" = Eingabe zu lang (disabled)
+input[text] "propertiesPanel.pattern" = 
+input[text] "propertiesPanel.patternWarnMessage" = Eingabe entspricht nicht der Vorgabe (disabled)
+checkbox "propertiesPanel.clearable" = false
+[Tastatur]
+checkbox "propertiesPanel.showSoftwareKeyboard" = false
+checkbox "propertiesPanel.hideNativeKeyboard" = false (disabled)
+checkbox "propertiesPanel.addInputAssistanceToKeyboard" = false (disabled)
+[Eingabehilfe]
+select "propertiesPanel.inputAssistance" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 100
+input[number] "propertiesPanel.height" = 30
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = #f1f1f1
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'text-field-simple|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-field-simple
+[Eingabeelement]
+checkbox "propertiesPanel.readOnly" = false
+input[text] "preset" = 
+[propertiesPanel.textAlign]
+toggle-group [format_align_left, format_align_center, format_align_right]
+checkbox "propertiesPanel.isWidthFixed" = false
+input[number] "propertiesPanel.width" = 100 (disabled)
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'text-field|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-field
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+input[text] "preset" = 
+[propertiesPanel.textAlign]
+toggle-group [format_align_left, format_align_center, format_align_right]
+select "propertiesPanel.appearance" = outline
+input[number] "propertiesPanel.minLength" = 
+input[text] "propertiesPanel.minLengthWarnMessage" = Eingabe zu kurz (disabled)
+input[number] "propertiesPanel.maxLength" = 
+checkbox "propertiesPanel.isLimitedToMaxLength" = true (disabled)
+input[text] "propertiesPanel.maxLengthWarnMessage" = Eingabe zu lang (disabled)
+input[text] "propertiesPanel.pattern" = 
+input[text] "propertiesPanel.patternWarnMessage" = Eingabe entspricht nicht der Vorgabe (disabled)
+checkbox "propertiesPanel.clearable" = false
+[Tastatur]
+checkbox "propertiesPanel.showSoftwareKeyboard" = false
+checkbox "propertiesPanel.hideNativeKeyboard" = false (disabled)
+checkbox "propertiesPanel.addInputAssistanceToKeyboard" = false (disabled)
+[Eingabehilfe]
+select "propertiesPanel.inputAssistance" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 120
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'text-field|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text-field
+[Eingabeelement]
+textarea "propertiesPanel.label" = 
+checkbox "propertiesPanel.readOnly" = false
+input[text] "preset" = 
+[propertiesPanel.textAlign]
+toggle-group [format_align_left, format_align_center, format_align_right]
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'text|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text
+button "edit"
+input[number] "propertiesPanel.columnCount" = 1
+[propertiesPanel.marking]
+checkbox "propertiesPanel.highlightableYellow" = false
+checkbox "propertiesPanel.highlightableTurquoise" = false
+checkbox "propertiesPanel.highlightableOrange" = false
+select "propertiesPanel.markingPanels" = []
+select "propertiesPanel.markingMode" = selection
+checkbox "propertiesPanel.hasSelectionPopup" = false (disabled)
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 98
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 135
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'text|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = text
+button "edit"
+input[number] "propertiesPanel.columnCount" = 1
+[propertiesPanel.marking]
+checkbox "propertiesPanel.highlightableYellow" = false
+checkbox "propertiesPanel.highlightableTurquoise" = false
+checkbox "propertiesPanel.highlightableOrange" = false
+select "propertiesPanel.markingPanels" = []
+select "propertiesPanel.markingMode" = selection
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'toggle-button|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = toggle-button
+[Eingabeelement]
+checkbox "propertiesPanel.readOnly" = false
+checkbox "propertiesPanel.requiredField" = false
+input[text] "propertiesPanel.requiredWarnMessage" = Eingabe erforderlich (disabled)
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+button "build"
+button "clear"
+button "build"
+button "clear"
+checkbox "propertiesPanel.strikeOtherOptions" = false
+checkbox "propertiesPanel.strikeSelectedOption" = false
+checkbox "propertiesPanel.verticalOrientation" = false
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 30
+
+--- tab "styling" ---
+input[text] "propertiesPanel.selectionColor" = #c9e0e0
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+input[number] "propertiesPanel.lineHeight" = 100
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'toggle-button|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = toggle-button
+[Eingabeelement]
+checkbox "propertiesPanel.readOnly" = false
+select "preset" = <null>
+[propertiesPanel.options]
+textarea "Neue Option" = 
+button "build"
+button "clear"
+button "build"
+button "clear"
+checkbox "propertiesPanel.strikeSelectedOption" = false
+checkbox "propertiesPanel.verticalOrientation" = false
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'trigger|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = trigger
+[propertiesPanel.action]
+select "propertiesPanel.action" = <null>
+select "propertiesPanel.actionParam" = <null>
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = transparent
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'trigger|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = trigger
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'video|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = video
+button "Medienoptionen anpassen"
+checkbox "propertiesPanel.scale" = false
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 280
+input[number] "propertiesPanel.height" = 230
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = #f1f1f1
+input[text] "propertiesPanel.fontColor" = #000000
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'video|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = video
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'widget-molecule-editor|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = widget-molecule-editor
+[toolbox.widget-molecule-editor]
+select "propertiesPanel.bondingType" = VALENCE
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 60
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = #f1f1f1
+input[text] "propertiesPanel.fontColor" = #006064
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+[Rahmen]
+input[number] "propertiesPanel.borderRadius" = 0
+input[text] "propertiesPanel.borderColor" = black
+select "propertiesPanel.borderStyle" = solid
+input[number] "propertiesPanel.borderWidth" = 0
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'widget-molecule-editor|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = widget-molecule-editor
+[toolbox.widget-molecule-editor]
+select "propertiesPanel.bondingType" = VALENCE
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`,
+
+  'widget-periodic-table|expert': `--- tabs --- element properties, position and size, styling
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = widget-periodic-table
+[toolbox.widget-periodic-table]
+checkbox "propertiesPanel.showInfoOrder" = true
+checkbox "propertiesPanel.showInfoENeg" = false
+checkbox "propertiesPanel.showInfoAMass" = true
+checkbox "propertiesPanel.closeOnSelection" = false
+input[number] "propertiesPanel.maxNumberOfSelections" = 1
+checkbox "propertiesPanel.isRelevantForPresentationComplete" = true
+
+--- tab "position and size" ---
+[Position]
+input[number] "propertiesPanel.xPosition" = 0
+input[number] "propertiesPanel.yPosition" = 0
+input[number] "propertiesPanel.zIndex" = 0
+[Dimensionen]
+input[number] "propertiesPanel.width" = 180
+input[number] "propertiesPanel.height" = 60
+
+--- tab "styling" ---
+input[text] "propertiesPanel.backgroundColor" = #f1f1f1
+input[text] "propertiesPanel.fontColor" = #006064
+input[number] "propertiesPanel.fontSize" = 20
+checkbox "propertiesPanel.bold" = false
+checkbox "propertiesPanel.italic" = false
+checkbox "propertiesPanel.underline" = false
+[Rahmen]
+input[number] "propertiesPanel.borderRadius" = 0
+input[text] "propertiesPanel.borderColor" = black
+select "propertiesPanel.borderStyle" = solid
+input[number] "propertiesPanel.borderWidth" = 0
+
+--- footer ---
+checkbox "propertiesPanel.setElementInteractionEnabled" = false
+button "propertiesPanel.duplicateElement"
+button "propertiesPanel.deleteElement"`,
+
+  'widget-periodic-table|standard': `--- tabs --- element properties
+
+--- tab "element properties" ---
+input[text] "propertiesPanel.id" = widget-periodic-table
+[toolbox.widget-periodic-table]
+checkbox "propertiesPanel.showInfoOrder" = true
+checkbox "propertiesPanel.showInfoENeg" = false
+checkbox "propertiesPanel.showInfoAMass" = true
+checkbox "propertiesPanel.closeOnSelection" = false
+input[number] "propertiesPanel.maxNumberOfSelections" = 1
+checkbox "propertiesPanel.maxWidthEnabled" = false
+input[number] "propertiesPanel.maxWidth" =  (disabled)
+
+--- footer ---
+button "propertiesPanel.deleteElement"`
+};

--- a/projects/editor/src/app/components/properties-panel/properties-panel.characterization.spec.ts
+++ b/projects/editor/src/app/components/properties-panel/properties-panel.characterization.spec.ts
@@ -1,0 +1,564 @@
+/**
+ * Characterization test for the whole element properties panel.
+ *
+ * Purpose: lock down *what the user sees* for every element type, so the panel can be
+ * restructured (own module, typed properties, split by inheritance) without silently
+ * losing or gaining a control. The 75 `property !== undefined` conditions in the panel
+ * templates are invisible to the compiler — a renamed property makes a control vanish
+ * without any test failing. This spec closes that gap.
+ *
+ * Deliberately NOT part of the baseline: which component renders a control. The baseline
+ * records label, control kind and current value only. That is what keeps it valid across
+ * a restructuring — moving a checkbox into another component must not change the baseline,
+ * losing the checkbox must.
+ *
+ * The expectations live in `properties-panel.baseline.ts` rather than in a vitest snapshot:
+ * the `@angular/build:unit-test` builder compiles specs into a timestamped directory under
+ * `dist/test-out/`, so `.snap` files are rewritten from scratch on every run and can never
+ * fail. The baseline is generated (by the skipped test at the bottom of this file) but
+ * committed, so a diff in it is reviewable. Treat any diff as a behaviour change — never
+ * regenerate it just to make the suite pass.
+ *
+ * Known gaps, deliberately left open:
+ * - `mat-select` options only exist while the overlay is open, so the baseline records a
+ *   select's current value but not the options it offers.
+ * - The panel host's input bindings for the position and styling tabs are mirrored in
+ *   `renderPanel()` (see the comment there), so a change to those two bindings is not caught.
+ * - Multi-selection is covered by `element-properties-panel.component.spec.ts`, not here.
+ */
+import {
+  ComponentFixture, fakeAsync, TestBed, tick
+} from '@angular/core/testing';
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSelect, MatSelectModule } from '@angular/material/select';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatTabsModule } from '@angular/material/tabs';
+import { By } from '@angular/platform-browser';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { UIElement } from 'common/models/elements/element';
+import { UIElementType } from 'common/models/ui-element-interfaces';
+import { ElementFactory } from 'common/utils/element-factory';
+import { SafeResourceHTMLPipe } from 'common/pipes/safe-resource-html.pipe';
+import { ScrollPagesPipe } from 'common/pipes/scroll-pages.pipe';
+import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
+import { DialogService } from 'editor/src/app/services/dialog.service';
+import { ElementService } from 'editor/src/app/services/element.service';
+import { MessageService } from 'editor/src/app/services/message.service';
+import { SectionService } from 'editor/src/app/services/section.service';
+import { SelectionService } from 'editor/src/app/services/selection.service';
+import { UnitService } from 'editor/src/app/services/unit.service';
+import { GetStateVariablePipe } from 'editor/src/app/pipes/get-state-variable.pipe';
+import { GetValidDropListsPipe } from 'editor/src/app/pipes/get-valid-drop-lists.pipe';
+import { IsInputElementPipe } from 'editor/src/app/pipes/is-input-element.pipe';
+import { LikertRowLabelPipe } from 'editor/src/app/pipes/likert-row-label.pipe';
+import { ScrollPageIndexPipe } from 'editor/src/app/pipes/scroll-page-index.pipe';
+import { SizeInputPanelComponent } from 'editor/src/app/components/size-input-panel/size-input-panel.component';
+import {
+  PANEL_BASELINE
+} from 'editor/src/app/components/properties-panel/properties-panel.baseline';
+import {
+  ElementPropertiesPanelComponent
+} from 'editor/src/app/components/properties-panel/element-properties-panel/element-properties-panel.component';
+import {
+  ElementPositionPropertiesComponent
+} from 'editor/src/app/components/properties-panel/element-position-properties/element-position-properties.component';
+import {
+  ElementStylePropertiesComponent
+} from 'editor/src/app/components/properties-panel/element-style-properties/element-style-properties.component';
+import {
+  DimensionFieldSetComponent
+} from 'editor/src/app/components/properties-panel/dimension-field-set/dimension-field-set.component';
+import {
+  PositionFieldSetComponent
+} from 'editor/src/app/components/properties-panel/position-field-set/position-field-set.component';
+import {
+  OptionListPanelComponent
+} from 'editor/src/app/components/properties-panel/option-list-panel/option-list-panel.component';
+import {
+  ElementModelPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/element-model-properties/element-model-properties.component';
+import {
+  EleSpecificPropsComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/ele-specific-props/ele-specific-props.component';
+import {
+  ActionParamStateVariableComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/action-param-state-variable/action-param-state-variable.component';
+import {
+  ActionPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/action-properties/action-properties.component';
+import {
+  BorderPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/border-properties/border-properties.component';
+import {
+  ButtonPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/button-properties/button-properties.component';
+import {
+  DropListPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/drop-list-properties/drop-list-properties.component';
+import {
+  GeometryPropsComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/geometry-props/geometry-props.component';
+import {
+  HighlightPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/highlight-properties/highlight-properties.component';
+import {
+  HotspotPropsComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/hotspot-props/hotspot-props.component';
+import {
+  InputAssistancePropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/input-assistance-properties/input-assistance-properties.component';
+import {
+  InputElementPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/input-element-properties/input-element-properties.component';
+import {
+  MarkingPanelPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/marking-panel-properties/marking-panel-properties.component';
+import {
+  MathFieldPropsComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/math-field-props/math-field-props.component';
+import {
+  MathTablePropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/math-table-properties/math-table-properties.component';
+import {
+  OptionsFieldSetComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/options-field-set/options-field-set.component';
+import {
+  PresetValuePropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/preset-value-properties/preset-value-properties.component';
+import {
+  ScaleAndZoomPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/scale-and-zoom-properties/scale-and-zoom-properties.component';
+import {
+  SelectPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/select-properties/select-properties.component';
+import {
+  SliderPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/slider-properties/slider-properties.component';
+import {
+  TablePropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/table-properties/table-properties.component';
+import {
+  TextFieldElementPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/text-field-element-properties/text-field-element-properties.component';
+import {
+  TextPropsComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/text-properties-field-set/text-properties-field-set.component';
+import {
+  WidgetMoleculeEditorPropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/widget-molecule-editor-properties/widget-molecule-editor-properties.component';
+import {
+  WidgetPeriodicTablePropertiesComponent
+} from 'editor/src/app/components/properties-panel/model-properties-tab/widget-periodic-table-properties/widget-periodic-table-properties.component';
+
+/** Stand-in for the MathLive-backed input; its internals are out of scope here. */
+@Component({ selector: 'aspect-math-input', standalone: false, template: '' })
+class MockMathInputComponent {
+  @Input() value!: string;
+  @Input() fullWidth: boolean = true;
+  @Input() readonly: boolean = false;
+  @Input() enableModeSwitch: boolean = false;
+  @Input() mathKeyboardPresets: string[] = [];
+  @Input() placeholder: string = '';
+}
+
+/**
+ * Exhaustive over UIElementType — a new element type is a compile error here until it is
+ * listed, which forces a decision about its properties panel.
+ */
+const ELEMENT_TYPE_COVERAGE: Record<UIElementType, true> = {
+  text: true,
+  button: true,
+  'text-field': true,
+  'text-field-simple': true,
+  'text-area': true,
+  checkbox: true,
+  dropdown: true,
+  radio: true,
+  image: true,
+  audio: true,
+  video: true,
+  likert: true,
+  'likert-row': true,
+  'radio-group-images': true,
+  'hotspot-image': true,
+  'drop-list': true,
+  cloze: true,
+  'spell-correct': true,
+  slider: true,
+  frame: true,
+  'toggle-button': true,
+  geometry: true,
+  'math-field': true,
+  'math-table': true,
+  'text-area-math': true,
+  trigger: true,
+  table: true,
+  'marking-panel': true,
+  'widget-periodic-table': true,
+  'widget-molecule-editor': true
+};
+
+const ELEMENT_TYPES = Object.keys(ELEMENT_TYPE_COVERAGE).sort() as UIElementType[];
+
+function normalizeText(node: Element | null): string {
+  return (node?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function shorten(value: string): string {
+  return value.length > 40 ? `${value.slice(0, 37)}…` : value;
+}
+
+function flags(control: Element): string {
+  const disabled = control.hasAttribute('disabled') ||
+    (control as HTMLInputElement).disabled === true;
+  return disabled ? ' (disabled)' : '';
+}
+
+/**
+ * A `mat-select`'s options live in an overlay that only exists while the select is open, so
+ * its selected value cannot be read from the DOM. This maps each select element to the value
+ * held by its directive instance.
+ */
+type SelectValues = Map<Element, unknown>;
+
+function formatValue(value: unknown): string {
+  if (value === null) return '<null>';
+  if (value === undefined) return '<undefined>';
+  if (Array.isArray(value)) return `[${value.map(entry => formatValue(entry)).join(', ')}]`;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function describeFormField(field: Element, selectValues: SelectValues): string {
+  const label = normalizeText(field.querySelector('mat-label')) || '<no label>';
+  const select = field.querySelector('mat-select');
+  if (select) {
+    const multiple = select.getAttribute('aria-multiselectable') === 'true' ? '[multiple]' : '';
+    return `select${multiple} "${label}" = ` +
+      `${shorten(formatValue(selectValues.get(select)))}${flags(select)}`;
+  }
+  const textarea = field.querySelector('textarea') as HTMLTextAreaElement | null;
+  if (textarea) return `textarea "${label}" = ${shorten(textarea.value)}${flags(textarea)}`;
+  const input = field.querySelector('input') as HTMLInputElement | null;
+  if (input) return `input[${input.type}] "${label}" = ${shorten(input.value)}${flags(input)}`;
+  return `field "${label}"`;
+}
+
+function describeCheckbox(checkbox: Element): string {
+  const input = checkbox.querySelector('input') as HTMLInputElement | null;
+  const state = input?.indeterminate ? 'indeterminate' : String(input?.checked ?? false);
+  return `checkbox "${normalizeText(checkbox)}" = ${state}${input ? flags(input) : ''}`;
+}
+
+function describeToggleGroup(group: Element): string {
+  const options = Array.from(group.querySelectorAll('mat-button-toggle'))
+    .map(toggle => {
+      const pressed = toggle.querySelector('button')?.getAttribute('aria-pressed') === 'true';
+      return `${normalizeText(toggle)}${pressed ? '*' : ''}`;
+    });
+  return `toggle-group [${options.join(', ')}]`;
+}
+
+/**
+ * Renders the visible controls of a subtree as one line each, in document order.
+ * Recognised controls are not descended into, so their inner buttons are not counted twice.
+ */
+function describeControls(root: Element, selectValues: SelectValues): string[] {
+  const lines: string[] = [];
+
+  const walk = (element: Element): void => {
+    switch (element.tagName.toLowerCase()) {
+      case 'mat-form-field':
+        lines.push(describeFormField(element, selectValues));
+        return;
+      case 'mat-checkbox':
+        lines.push(describeCheckbox(element));
+        return;
+      case 'mat-button-toggle-group':
+        lines.push(describeToggleGroup(element));
+        return;
+      case 'mat-slider':
+        lines.push(`slider "${normalizeText(element.querySelector('input'))}"`);
+        return;
+      case 'mat-chip-grid':
+        lines.push(`chips [${Array.from(element.querySelectorAll('mat-chip-row'))
+          .map(chip => normalizeText(chip)).join(', ')}]`);
+        return;
+      case 'button':
+        lines.push(`button "${normalizeText(element)}"${flags(element)}`);
+        return;
+      case 'fieldset':
+        lines.push(`[${normalizeText(element.querySelector('legend')) || 'fieldset'}]`);
+        break;
+      default:
+        break;
+    }
+    Array.from(element.children).forEach(child => walk(child));
+  };
+
+  walk(root);
+  return lines;
+}
+
+describe('properties panel characterization', () => {
+  let fixture: ComponentFixture<ElementPropertiesPanelComponent>;
+  let selectedElements: BehaviorSubject<UIElement[]>;
+  let unitServiceMock: { expertMode: boolean } & Record<string, unknown>;
+
+  const unitMock = {
+    stateVariables: [],
+    pages: [{ sections: [{ dynamicPositioning: false }] }],
+    getAllElements: () => []
+  };
+
+  beforeEach(async () => {
+    selectedElements = new BehaviorSubject<UIElement[]>([]);
+    unitServiceMock = {
+      expertMode: false,
+      elementPropertyUpdated: new Subject<void>(),
+      tablePropUpdated: new Subject<string>(),
+      unit: unitMock,
+      getAllDropListElementIDs: () => []
+    };
+    // GeometryPropsComponent reaches through the selected element's overlay into the rendered
+    // geometry component, so the selection needs an entry of that shape. It is not an
+    // ElementOverlay, so the panel's own `instanceof` checks skip it.
+    const geometryOverlayStub = {
+      childComponent: {
+        instance: {
+          isLoaded: new BehaviorSubject<boolean>(false),
+          getGeometryObjects: () => []
+        }
+      }
+    };
+    const selectionServiceMock = {
+      selectedElements: selectedElements.asObservable(),
+      selectedElementComponents: [geometryOverlayStub],
+      isCompoundChildSelected: false,
+      selectedPageIndex: 0,
+      selectedSectionIndex: 0,
+      getSelectedElements: () => selectedElements.value
+    };
+    const elementService: SpyObj<ElementService> = createSpyObj<ElementService>([
+      'updateElementsProperty', 'updateElementsDimensionsProperty', 'deleteElements',
+      'duplicateSelectedElements', 'showDefaultEditDialog', 'alignElements',
+      'updateSelectedElementsPositionProperty', 'updateSelectedElementsStyleProperty',
+      'updateDropListValueObject', 'createLikertRowElement'
+    ]);
+
+    await TestBed.configureTestingModule({
+      declarations: [
+        ElementPropertiesPanelComponent,
+        ElementModelPropertiesComponent,
+        ElementPositionPropertiesComponent,
+        ElementStylePropertiesComponent,
+        DimensionFieldSetComponent,
+        PositionFieldSetComponent,
+        OptionListPanelComponent,
+        EleSpecificPropsComponent,
+        ActionParamStateVariableComponent,
+        ActionPropertiesComponent,
+        BorderPropertiesComponent,
+        ButtonPropertiesComponent,
+        DropListPropertiesComponent,
+        GeometryPropsComponent,
+        HighlightPropertiesComponent,
+        HotspotPropsComponent,
+        InputAssistancePropertiesComponent,
+        InputElementPropertiesComponent,
+        MarkingPanelPropertiesComponent,
+        MathFieldPropsComponent,
+        MathTablePropertiesComponent,
+        OptionsFieldSetComponent,
+        PresetValuePropertiesComponent,
+        ScaleAndZoomPropertiesComponent,
+        SelectPropertiesComponent,
+        SliderPropertiesComponent,
+        TablePropertiesComponent,
+        TextFieldElementPropertiesComponent,
+        TextPropsComponent,
+        WidgetMoleculeEditorPropertiesComponent,
+        WidgetPeriodicTablePropertiesComponent,
+        SizeInputPanelComponent,
+        MockMathInputComponent,
+        GetStateVariablePipe,
+        GetValidDropListsPipe,
+        IsInputElementPipe,
+        LikertRowLabelPipe,
+        ScrollPageIndexPipe,
+        SafeResourceHTMLPipe,
+        ScrollPagesPipe
+      ],
+      imports: [
+        CommonModule,
+        FormsModule,
+        ReactiveFormsModule,
+        DragDropModule,
+        MatButtonModule,
+        MatButtonToggleModule,
+        MatCheckboxModule,
+        MatChipsModule,
+        MatDividerModule,
+        MatIconModule,
+        MatInputModule,
+        MatMenuModule,
+        MatSelectModule,
+        MatSliderModule,
+        MatTabsModule,
+        MatTooltipModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: SelectionService, useValue: selectionServiceMock as unknown as SelectionService },
+        { provide: UnitService, useValue: unitServiceMock as unknown as UnitService },
+        { provide: SectionService, useValue: {} as SectionService },
+        { provide: ElementService, useValue: elementService },
+        { provide: MessageService, useValue: createSpyObj<MessageService>(['showWarning', 'showError']) },
+        {
+          provide: DialogService,
+          useValue: createSpyObj<DialogService>([
+            'showTextEditDialog', 'showImageResizeDialog', 'showTooltipDialog',
+            'showLabelEditDialog', 'showLikertRowEditDialog', 'showRichTextEditDialog',
+            'showDropListOptionEditDialog', 'showHotspotEditDialog',
+            'showGeogebraAppDefinitionDialog', 'importImage'
+          ])
+        }
+      ]
+    }).compileComponents();
+  });
+
+  /** The panel labels its tabs with icons only; these are the readable equivalents. */
+  const TAB_NAMES: Record<string, string> = {
+    build: 'element properties',
+    format_shapes: 'position and size',
+    palette: 'styling'
+  };
+
+  function section(title: string, controls: string[]): string {
+    return [`--- ${title} ---`, ...controls].join('\n');
+  }
+
+  function selectValuesOf(rendered: ComponentFixture<unknown>): SelectValues {
+    return new Map(rendered.debugElement.queryAll(By.directive(MatSelect))
+      .map(select => [select.nativeElement as Element, (select.componentInstance as MatSelect).value]));
+  }
+
+  /**
+   * Settles a fixture: `NgModel` writes its initial value to the DOM in a microtask, so without
+   * flushing it every `[ngModel]`-bound field would be recorded as empty.
+   */
+  function settle(rendered: ComponentFixture<unknown>): void {
+    rendered.detectChanges();
+    tick();
+    rendered.detectChanges();
+  }
+
+  function describeFixture(rendered: ComponentFixture<unknown>, root?: Element): string[] {
+    return describeControls(root ?? rendered.nativeElement, selectValuesOf(rendered));
+  }
+
+  /**
+   * Renders the panel for one element and describes what it shows.
+   *
+   * Only the first tab's body is reachable through the host: Material attaches an inactive
+   * tab body's content on a transition event that never fires without an animations module
+   * (which rule 3 rules out). The remaining tabs are therefore rendered directly, gated by
+   * the tab list the host actually produced — so the expert-mode gating still comes from
+   * the real panel, only the rendering of those two tab bodies is short-circuited.
+   */
+  function renderPanel(type: UIElementType, expertMode: boolean): string {
+    unitServiceMock.expertMode = expertMode;
+    fixture = TestBed.createComponent(ElementPropertiesPanelComponent);
+    fixture.detectChanges();
+
+    const element = ElementFactory.createElement({ type, id: type, alias: type });
+    selectedElements.next([element]);
+    settle(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const tabs = Array.from(host.querySelectorAll('.mat-mdc-tab'))
+      .map(tab => TAB_NAMES[normalizeText(tab)] ?? normalizeText(tab));
+    const modelTab = host.querySelector('.mat-mdc-tab-body-active');
+    const footer = host.querySelector('.button-group');
+
+    const sections = [
+      `--- tabs --- ${tabs.join(', ')}`,
+      section(
+        `tab "${tabs[0]}"`,
+        modelTab ? describeFixture(fixture, modelTab) : ['<tab body not rendered>']
+      )
+    ];
+
+    if (tabs.includes('position and size')) {
+      const positionFixture = TestBed.createComponent(ElementPositionPropertiesComponent);
+      positionFixture.componentInstance.dimensions = type === 'trigger' ? null : element.dimensions;
+      positionFixture.componentInstance.positionProperties = element.position;
+      positionFixture.componentInstance.isZIndexDisabled = type === 'trigger';
+      settle(positionFixture);
+      sections.push(section('tab "position and size"', describeFixture(positionFixture)));
+    }
+
+    if (tabs.includes('styling')) {
+      const styleFixture = TestBed.createComponent(ElementStylePropertiesComponent);
+      styleFixture.componentInstance.styles = element.styling;
+      settle(styleFixture);
+      sections.push(section('tab "styling"', describeFixture(styleFixture)));
+    }
+
+    sections.push(section('footer', footer ? describeFixture(fixture, footer) : []));
+    return sections.join('\n\n');
+  }
+
+  /**
+   * Regenerates `properties-panel.baseline.ts`. Change `describe.skip` to `describe`, run
+   * `npx ng test editor --include "**\/properties-panel.characterization.spec.ts"`, replace the
+   * body of the baseline file with the logged block, and skip this block again. Always read the
+   * resulting diff — it is the list of behaviour changes the edit caused.
+   *
+   * `describe.skip` rather than `it.skip`: the ProxyZone setup replaces the global `it` and
+   * copies its modifiers with `Object.keys`, which does not reach vitest's `skip`/`only`.
+   */
+  describe.skip('baseline regeneration', () => {
+    it('logs a new baseline (see the doc comment before un-skipping)', fakeAsync(() => {
+      const entries = ELEMENT_TYPES.flatMap(type => [
+        [`${type}|standard`, renderPanel(type, false)] as const,
+        [`${type}|expert`, renderPanel(type, true)] as const
+      ]);
+      const escaped = entries
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([key, value]) => `  '${key}': \`${value
+          .replace(/\\/g, '\\\\')
+          .replace(/`/g, '\\`')
+          .replace(/\$\{/g, '\\${')}\``);
+      // eslint-disable-next-line no-console
+      console.log(`\n>>> COPY FROM HERE >>>\nexport const PANEL_BASELINE: Record<string, string> = {\n${
+        escaped.join(',\n\n')}\n};\n<<< COPY TO HERE <<<`);
+    }));
+  });
+
+  // Generated with plain `it` rather than `it.each`: the project's ProxyZone setup
+  // (projects/vitest-proxy-zone.setup.ts) only patches `it`/`test`, so `fakeAsync` inside
+  // `it.each` fails with "Expected to be running in 'ProxyZone'".
+  ELEMENT_TYPES.forEach(type => {
+    it(`should render the standard panel for "${type}"`, fakeAsync(() => {
+      expect(renderPanel(type, false)).toBe(PANEL_BASELINE[`${type}|standard`]);
+    }));
+
+    it(`should render the expert panel for "${type}"`, fakeAsync(() => {
+      expect(renderPanel(type, true)).toBe(PANEL_BASELINE[`${type}|expert`]);
+    }));
+  });
+});


### PR DESCRIPTION
Absicherung für den geplanten Umbau des Properties-Panels: ein Charakterisierungsnetz über das
zusammengesetzte Panel plus vollständige Tests für die Merge-Logik der Mehrfachauswahl.

Kein Produktivcode geändert.

## Warum

Das Panel entscheidet über **75** Bedingungen der Form `combinedProperties.xy !== undefined`, welche
Controls es zeigt; die Property-Namen in `updateModel.emit({ property: 'xy', … })` sind Strings.
Beides sieht der Compiler nicht — wird ein Property umbenannt, verschwindet ein Control lautlos.
Die Komponenten-Specs aus #1114 prüfen jede Komponente einzeln mit gemockten Kindern und können das
nicht auffangen.

## Was drin ist

`properties-panel.characterization.spec.ts` rendert das echte Panel mit allen 31 Komponenten (keine
Mock-Kinder) für alle 30 `UIElementType`, je mit und ohne Expertenmodus → 60 Baseline-Einträge.

Erfasst wird pro Control eine Zeile mit Label, Art, aktuellem Wert, `disabled`/`indeterminate` und
Fieldset-Struktur — **nicht** die rendernde Komponente. Genau das macht die Baseline über den Umbau
hinweg gültig: ein Control in eine andere Komponente zu verschieben ändert nichts, es zu verlieren
schon.

`Record<UIElementType, true>` als Abdeckungsprüfung: ein neuer Elementtyp ist ein Compilerfehler,
bis er gelistet ist.

Dazu `createCombinedProperties()` von 4 auf 13 Tests: rekursiver Merge der Property-Gruppen, `null`
bei Divergenz für Primitives und Arrays, gleiche Arrays bleiben erhalten, die beiden Keys die der
Merge selbst hinzufügt (`idList`, `rows`), die frische `rows`-Referenz für die Change Detection,
`type` bei gemischter Auswahl.

## Wirkung verifiziert

Nicht behauptet, sondern per Mutation am Produktivcode geprüft (danach zurückgenommen):

| Mutation | rote Tests |
| --- | --- |
| `verticalOrientation` in einer `*ngIf`-Bedingung umbenannt | 2 (`toggle-button`) |
| `readOnly`-Checkbox entfernt | 30 (alle Eingabeelemente) |

## Warum kein vitest-Snapshot

`toMatchSnapshot()` ist mit dem `@angular/build:unit-test`-Builder wirkungslos: Specs werden nach
`dist/test-out/<timestamp>/` kompiliert, die `.snap`-Dateien landen dort und werden bei jedem Lauf
neu geschrieben — der Test kann nie fehlschlagen. Die Baseline liegt daher als versionierte
TypeScript-Datei im Repo; regeneriert wird sie über einen geskippten `describe`-Block im Spec, sodass
jede Änderung als reviewbarer Diff sichtbar wird.

## Nebenbefund (nicht angefasst)

`projects/vitest-proxy-zone.setup.ts` verliert die Modifier des globalen `it`. Der Kommentar dort
sagt, `skip`/`only`/`todo` blieben verfügbar, aber `Object.keys` erfasst sie in vitest 3 nicht →
`it.skip` ist `undefined`. Zusätzlich ist `it.each` nicht Zone-gewrappt, `fakeAsync` schlägt darin
mit „Expected to be running in 'ProxyZone'" fehl (deshalb hier `describe.skip` und eine
`forEach`-Schleife mit einfachem `it`). Ein Kopieren über `Reflect.ownKeys` +
`Object.getOwnPropertyDescriptor` würde beides projektweit reparieren — als geteilte
Test-Infrastruktur bewusst nicht in diesem PR.

## Bekannte Lücken

Im Spec-Header dokumentiert:

- `mat-select`: Optionen existieren nur im geöffneten Overlay; die Baseline hält den gewählten Wert,
  nicht die Auswahlliste.
- Die Material-Tab-Bodies aktivieren sich ohne Animations-Modul (Regel 3) nie. Der Modell-Tab kommt
  aus dem Host, Position und Gestaltung aus direkt gerenderten Fixtures; die beiden Input-Bindings
  des Hosts für diese Tabs sind im Test gespiegelt und dadurch nicht abgedeckt.
- Mehrfachauswahl bleibt in `element-properties-panel.component.spec.ts`.

## Testlauf

Komplette Kette grün:

| Suite | Tests |
| --- | --- |
| `test:common` | 529 |
| `test:player-modules` | 123 |
| `test:editor` | 601 (+1 geskippt) |
| `test:editor-modules` | 159 |
| `test:player` | 572 |
| **Summe** | **1984** (vorher 1915) |

Lint über die geänderten Dateien: 0 Errors (15 `max-len`-Warnings aus den langen Importpfaden, wie
in `app.module.ts`).

Betrifft #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
