### PR TITLE
vitest-ProxyZone-Patch: Modifier erhalten und Testkörper darin wrappen (#1130)

### DIFF
--- a/projects/common/vitest-proxy-zone.spec.ts
+++ b/projects/common/vitest-proxy-zone.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Guards `projects/vitest-proxy-zone.setup.ts`, which replaces the global `it`/`test` so that
+ * every test body runs inside a zone.js ProxyZone.
+ *
+ * Two regressions are covered:
+ * - Vitest's modifiers must survive the patch. They are non-enumerable getters, so a patch that
+ *   copies properties with `Object.keys` leaves `it.skip` and friends `undefined`. That fails at
+ *   file scope, which drops the whole spec file from the run while the test count still looks
+ *   green — so a missing modifier is easy to miss without this check.
+ * - Bodies reaching the runner through a modifier must be zone-wrapped too, otherwise
+ *   `fakeAsync` throws "Expected to be running in 'ProxyZone', but it was not found."
+ *
+ * `it.only` and `it.todo` are checked for availability only: calling them would restrict or
+ * change the run. `it.fails` is unusable as a check here — it passes on any error, including the
+ * missing-ProxyZone error it is supposed to catch.
+ */
+import { fakeAsync, tick } from '@angular/core/testing';
+
+describe('vitest ProxyZone setup', () => {
+  const modifiers = ['skip', 'only', 'todo', 'fails', 'concurrent', 'sequential', 'each', 'for'];
+
+  it('should keep every Vitest modifier available on it and test', () => {
+    const globals = { it, test } as unknown as Record<string, Record<string, unknown>>;
+
+    Object.entries(globals).forEach(([name, global]) => {
+      modifiers.forEach(modifier => {
+        expect(typeof global[modifier], `${name}.${modifier}`).toBe('function');
+      });
+    });
+  });
+
+  it('should run a plain test body inside a ProxyZone', fakeAsync(() => {
+    let elapsed = false;
+    setTimeout(() => { elapsed = true; }, 100);
+
+    tick(100);
+
+    expect(elapsed).toBe(true);
+  }));
+
+  it.each([1, 2])('should run an it.each body inside a ProxyZone (case %s)', fakeAsync(() => {
+    let elapsed = false;
+    setTimeout(() => { elapsed = true; }, 100);
+
+    tick(100);
+
+    expect(elapsed).toBe(true);
+  }));
+
+  // The wrapper must forward its arguments, otherwise a body relying on Vitest's test context
+  // or on the value supplied by `it.each` would silently receive nothing.
+  it('should forward the Vitest test context to the body', context => {
+    expect(context).toBeDefined();
+    expect(context.task.name).toContain('forward the Vitest test context');
+  });
+
+  it.each(['alpha', 'beta'])('should forward the it.each value to the body (%s)', value => {
+    expect(['alpha', 'beta']).toContain(value);
+  });
+});

--- a/projects/vitest-proxy-zone.setup.ts
+++ b/projects/vitest-proxy-zone.setup.ts
@@ -8,6 +8,11 @@
  *
  * 'zone.js' and 'zone.js/testing' are loaded beforehand via the polyfills of
  * the build target referenced by the '@angular/build:unit-test' builder.
+ *
+ * The patch keeps Vitest's modifiers intact and zone-wraps the bodies reaching them, so
+ * `it.skip`, `it.only` and `it.each` work with `fakeAsync`/`tick`. See
+ * `projects/common/vitest-proxy-zone.spec.ts`. `describe` is deliberately not patched —
+ * it does not take a test body.
  */
 
 type TestFunction = (...args: unknown[]) => unknown;
@@ -39,30 +44,64 @@ const wrapTestInProxyZone = (fn: TestFunction): TestFunction => {
     const proxyZone = zoneStatic.root.fork(new zoneStatic.ProxyZoneSpec());
     return proxyZone.run(fn, this, args);
   };
-  // Preserve the arity so runners relying on fn.length keep working.
+  // Preserve the arity: Vitest passes the test context only to bodies that declare a parameter.
   Object.defineProperty(wrapped, 'length', { value: fn.length });
   return wrapped;
 };
 
-type ItFunction = ((name: string, fn?: TestFunction, timeout?: number) => unknown) &
-Record<string, unknown>;
+/**
+ * A test declaration is `(name, body, timeout?)`. Every other call shape on the same chain —
+ * `each(table)`, `for(table)`, `extend(fixtures)`, `skipIf(condition)` — must pass through
+ * unchanged; those return the function that then receives the body.
+ */
+const isTestDeclaration = (args: unknown[]): boolean => (
+  typeof args[0] === 'string' && typeof args[1] === 'function'
+);
 
-const patchTestFunction = (original: ItFunction): ItFunction => {
-  const patched = ((name: string, fn?: TestFunction, timeout?: number) => (
-    original(name, fn ? wrapTestInProxyZone(fn) : fn, timeout)
-  )) as ItFunction;
-  // Keep modifiers (only/skip/todo/…) available, albeit without zone wrapping;
-  // the project's specs exclusively use plain `it(...)`/`test(...)` calls.
-  Object.keys(original).forEach(key => {
-    patched[key] = original[key];
-  });
-  return patched;
-};
+/**
+ * Function-valued members that must be forwarded as they are. `fn` is Vitest's underlying
+ * implementation and is compared by identity internally; the rest are Function.prototype
+ * members that callers may legitimately want unwrapped.
+ */
+const PASS_THROUGH = new Set(['fn', 'bind', 'call', 'apply', 'constructor', 'toString']);
+
+/**
+ * Wraps a chainable test function so that every body reaching it runs in a ProxyZone —
+ * plain `it(…)` as well as bodies passed through a modifier such as `it.only(…)` or
+ * `it.each(table)(…)`.
+ *
+ * A Proxy is used instead of copying properties onto a replacement function: Vitest defines
+ * `skip`, `only`, `todo`, `fails`, `concurrent` and `sequential` as non-enumerable getters, so
+ * `Object.keys` does not report them and copying leaves them `undefined`. That turned
+ * `it.skip(…)` into a `TypeError` at file scope, which drops the whole spec file from the run
+ * while the test count still looks green.
+ */
+const wrapChainable = (target: TestFunction): TestFunction => new Proxy(target, {
+  apply(chainable: TestFunction, thisArg: unknown, args: unknown[]): unknown {
+    const result = Reflect.apply(
+      chainable,
+      thisArg,
+      isTestDeclaration(args) ?
+        [args[0], wrapTestInProxyZone(args[1] as TestFunction), ...args.slice(2)] :
+        args
+    );
+    // `it.each(table)` and friends return the function that receives the body.
+    return typeof result === 'function' ? wrapChainable(result as TestFunction) : result;
+  },
+  get(chainable: TestFunction, property: string | symbol): unknown {
+    const value = Reflect.get(chainable, property);
+    if (typeof value !== 'function' || typeof property === 'symbol' ||
+      PASS_THROUGH.has(property)) {
+      return value;
+    }
+    return wrapChainable(value as TestFunction);
+  }
+});
 
 const globalScope = globalThis as unknown as Record<string, unknown>;
 ['it', 'test'].forEach(name => {
   const original = globalScope[name];
   if (typeof original === 'function') {
-    globalScope[name] = patchTestFunction(original as ItFunction);
+    globalScope[name] = wrapChainable(original as TestFunction);
   }
 });


### PR DESCRIPTION
Behebt beide in #1130 beschriebenen Defekte in `projects/vitest-proxy-zone.setup.ts`.

## Ursache

Der Patch ersetzte die globalen `it`/`test` durch eine Wrapper-Funktion und übernahm die Modifier
mit `Object.keys(original)`. Bei vitest 3 sind `skip`, `only`, `todo`, `fails`, `concurrent` und
`sequential` aber **nicht enumerable** — `createChainable` legt sie per `Object.defineProperty` als
Getter an. Gemessen an der laufenden Suite:

```
Object.keys(vitestIt)     → each, for, skipIf, runIf, scoped, extend, withContext,
                            setContext, mergeContext, fn
Reflect.ownKeys(vitestIt) → … + concurrent, sequential, skip, only, todo, fails
```

Zweitens landete `it.each` in vitests interner `it`-Implementierung statt in der gepatchten
globalen, sodass die Testkörper nicht gewrappt wurden und `fakeAsync` darin scheiterte.

## Änderung

Statt Properties zu kopieren jetzt ein rekursiver `Proxy`:

- `get` leitet jedes Member weiter — die Getter bleiben also erhalten, egal ob enumerable oder nicht
- `apply` wrappt den Testkörper, wenn der Aufruf die Form `(name: string, body: function, …)` hat,
  und lässt alle anderen Aufrufformen (`each(table)`, `extend(fixtures)`, `skipIf(condition)`)
  unangetastet
- der Rückgabewert wird mitgewrappt, weil `it.each(table)` erst die Funktion liefert, die den Körper
  bekommt
- `fn` (vitests interne Implementierung, wird per Identität verglichen) und die
  `Function.prototype`-Member gehen unverändert durch

Nebenbei korrigiert: der Kommentar im Setup behauptete, die Modifier blieben verfügbar.

## Wirkung belegt

`projects/common/vitest-proxy-zone.spec.ts` prüft beides. Gegen die **vorherige** Implementierung:

```
× should keep every Vitest modifier available on it and test
  → it.skip: expected 'undefined' to be 'function'
× should run an it.each body inside a ProxyZone (case 1)
  → Expected to be running in 'ProxyZone', but it was not found.
× should run an it.each body inside a ProxyZone (case 2)
  → Expected to be running in 'ProxyZone', but it was not found.
```

Mit der neuen: 7 von 7 grün.

`it.only` und `it.todo` werden nur auf Verfügbarkeit geprüft — sie aufzurufen würde den Lauf
einschränken bzw. verändern. `it.fails` ist als Prüfmittel untauglich: es besteht bei *jedem* Fehler,
also auch bei genau dem ProxyZone-Fehler, den es nachweisen sollte. Das steht so im Spec-Header.

## Warum das wichtig ist

Der erste Defekt schlägt nicht als Test fehl, sondern beim Einlesen der Spec-Datei. Die Datei fällt
komplett aus der Suite, und der Zähler sieht weiter grün aus — `Tests 601 passed` bei gleichzeitig
`Test Files 1 failed`. Genau so ist es beim Charakterisierungsnetz (#1127) aufgefallen.

## Testlauf

Komplette Kette grün:

| Suite | Tests |
| --- | --- |
| `test:common` | 536 (+7 neu) |
| `test:player-modules` | 123 |
| `test:editor` | 532 |
| `test:editor-modules` | 159 |
| `test:player` | 572 |
| **Summe** | **1922** |

Lint der geänderten Dateien: 0 Errors, 0 Warnings.

Ein erster Durchlauf zeigte zwei `common`-Dateien mit `Failed to fetch dynamically imported module`;
beim Wiederholen (einzeln und als ganze Kette) reproduzierbar nicht mehr auftretend — Flakiness der
Modulauslieferung des Test-Builders, kein Zusammenhang mit dieser Änderung.

## Folgearbeit

In `properties-panel.characterization.spec.ts` (PR #1128) sind zwei Umgehungen drin, die nach diesem
Merge entfallen können: `describe.skip` statt `it.skip` und eine `forEach`-Schleife statt `it.each`.
Das nehme ich bei der Modul-Extraktion des Panels mit, weil das Spec dort ohnehin angefasst wird.

Betrifft #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
