### PR TITLE
E2E-Startfehler diagnostizierbar machen und wiederholen

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,19 +28,26 @@ test-e2e:
   before_script:
     - npm ci --cache .npm --prefer-offline
   script:
-    - nohup npm run start-editor-local &
-    - nohup npm run start-player-local &
-    - |
-      echo "Waiting for editor..."
-      until curl -sSf http://localhost:4201 >/dev/null; do sleep 5; done
-      echo "Editor ready!"
-      echo "Waiting for player..."
-      until curl -sSf http://localhost:4202 >/dev/null; do sleep 5; done
-      echo "Player ready!"
+    # The server output goes to a log artifact: without it a dev server that dies or stops
+    # answering leaves no trace, and the run only shows Cypress' ESOCKETTIMEDOUT.
+    - nohup npm run start-editor-local > editor.log 2>&1 &
+    - nohup npm run start-player-local > player.log 2>&1 &
+    - ./scripts/wait-for-dev-server.sh http://localhost:4201 Editor
+    - ./scripts/wait-for-dev-server.sh http://localhost:4202 Player
     - npm run e2e-headless
+  # Both dev servers, Chrome and a second pipeline for the same commit share one runner, so
+  # the suite occasionally fails on startup rather than on an assertion. Retry once.
+  retry:
+    max: 1
+    when:
+      - script_failure
+      - runner_system_failure
+      - stuck_or_timeout_failure
   artifacts:
     when: always
     paths:
+      - editor.log
+      - player.log
       - e2e/downloads/**/*.*
       - e2e/videos/**/*.mp4
       - e2e/screenshots/**/*.png

--- a/scripts/wait-for-dev-server.sh
+++ b/scripts/wait-for-dev-server.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Waits until an Angular dev server answers, then warms up its main bundle.
+#
+# Replaces a plain "until curl; do sleep 5; done" loop in the CI e2e job, which had two
+# problems: it never gave up (a dev server that came up but stopped answering blocked the
+# job until the pipeline timeout), and it declared the server ready as soon as index.html
+# was served. The dev server answers index.html before it has served main.js, so the first
+# cy.visit() could still run into Cypress' 30s responseTimeout and fail the run with
+# ESOCKETTIMEDOUT.
+#
+# Usage: wait-for-dev-server.sh <url> <name> [timeout_seconds]
+
+set -euo pipefail
+
+url="$1"
+name="$2"
+timeout_seconds="${3:-300}"
+
+deadline=$((SECONDS + timeout_seconds))
+
+echo "Waiting for ${name} at ${url} (timeout ${timeout_seconds}s)..."
+until curl -sSf --max-time 10 "${url}" > /dev/null 2>&1; do
+  if [ "${SECONDS}" -ge "${deadline}" ]; then
+    echo "${name} did not answer within ${timeout_seconds}s - see the server log artifact." >&2
+    exit 1
+  fi
+  sleep 5
+done
+
+echo "${name} answered after ${SECONDS}s, warming up main bundle..."
+if curl -sSf --max-time 120 "${url}/main.js" > /dev/null 2>&1; then
+  echo "${name} ready after ${SECONDS}s!"
+else
+  # Not fatal: the run may still succeed, but the first cy.visit() then pays for the
+  # compile and the log tells us so if it times out instead.
+  echo "Warning: ${name} did not serve main.js (request failed or timed out) - continuing anyway." >&2
+fi


### PR DESCRIPTION
Der `test-e2e`-Job fällt gelegentlich aus, bevor ein einziges Assert läuft: `cy.visit()` bekommt vom Editor-Dev-Server keine Antwort und Cypress bricht den Lauf nach seinem 30-s-`responseTimeout` mit `ESOCKETTIMEDOUT` ab.

Die Last ist die wahrscheinliche Ursache: jeder Push erzeugt **zwei** Pipelines für denselben Commit (`source=push` und `source=external_pull_request_event`), die gleichzeitig auf demselben Runner laufen — also vier `ng serve`-Prozesse plus zwei Chrome-Instanzen. Beleg: Commit `2705e66b` lief in Pipeline 97383 grün und in 97384 rot.

Dieser PR ändert **keine Tests**, sondern macht den Start belastbar und im Fehlerfall überhaupt erst auswertbar:

- **Server-Logs werden gesichert.** Die Dev-Server schrieben nach `nohup.out`, das kein Artifact eingesammelt hat — ein gestorbener oder hängender Server hinterließ null Spuren. Ausgabe geht jetzt nach `editor.log`/`player.log`, beide werden mit `when: always` als Artifact eingesammelt.
- **Warten mit Obergrenze und Warm-up.** Die alte Schleife `until curl -sSf …; do sleep 5; done` gab nie auf (ein Server, der hochkam und dann verstummte, blockierte den Job bis zum Pipeline-Timeout) und erklärte den Server für bereit, sobald `index.html` ausgeliefert war — also bevor `main.js` kompiliert war, worauf Cypress dann wartet. Ersetzt durch `scripts/wait-for-dev-server.sh`: 5 Minuten Obergrenze pro Server und ein `main.js`-Request als Warm-up, damit der erste Kompilierlauf nicht in Cypress' Timeout-Fenster fällt.
- **Ein Retry** auf `script_failure`, `runner_system_failure` und `stuck_or_timeout_failure`.

## Bewusster Kompromiss

Der Retry greift auch bei **echten** Testfehlern — ein kaputter Test braucht dadurch zwei Läufe (~25 min mehr), bis die Pipeline rot meldet. Das ist der Preis dafür, dass Startprobleme keine Pipeline mehr rot machen.

## Test

`scripts/wait-for-dev-server.sh` ist lokal in allen drei Pfaden geprüft:

| Fall | Ergebnis |
| --- | --- |
| Server antwortet nie (Timeout 8 s) | Abbruch nach 10 s, Exit 1, Hinweis auf das Log-Artifact |
| Server mit `main.js` | Exit 0, „ready" |
| Server ohne `main.js` | Exit 0 mit Warnung (nicht fatal) |

`bash -n` und YAML-Parse der `.gitlab-ci.yml` laufen durch.

## Nicht Teil dieses PRs

- **Doppelpipelines abschalten** (`workflow:rules`) — das ist der eigentliche Hebel, braucht aber vorher die Klärung, welche der beiden Pipelines den GitHub-Pflichtstatus `ci/gitlab/scm.cms.hu-berlin.de` setzt.
- **`interruptible: true` + Auto-Cancel** — sinnvoll erst nach dem Dedupe, sonst können sich die zwei Zwillingspipelines (1 s Abstand, gleiche Ref) gegenseitig abbrechen. Die Projekteinstellung „Auto-cancel redundant pipelines" muss ohnehin in GitLab gesetzt werden.
- **`ng serve` durch statische Auslieferung ersetzen** — größter Effekt auf die Ressourcenlast, aber kein Einzeiler (`scripts/build.sh` erzeugt Single-File-HTML für den Deploy). Sinnvoll zu entscheiden, wenn die neuen Server-Logs zeigen, woran der Start scheitert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
