### PR TITLE
Pro Commit nur eine Pipeline statt zwei

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,27 @@ stages:
   - build
   - deploy
 
+# A push and the pull request GitLab mirrors from GitHub each start a pipeline for the same
+# commit. Both report to the same GitHub status context (ci/gitlab/scm.cms.hu-berlin.de), so
+# whichever finishes last decides whether the pull request looks green, and both compete for
+# the same runner - four ng serve processes and two Chrome instances at once, which is what
+# makes the e2e job time out during startup. Keep the pull request pipeline, which is the one
+# the required status check links to, and drop the redundant push pipeline on feature
+# branches. Consequence: a branch without an open pull request gets no pipeline.
+workflow:
+  auto_cancel:
+    on_new_commit: interruptible
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop" && $CI_COMMIT_BRANCH != "master"
+      when: never
+    - when: always
+
 default:
   image: iqbberlin/aspect-test:latest
+  # Lets a pipeline for a newer commit cancel this one instead of both queueing for the
+  # same runner. Effective through workflow:auto_cancel above.
+  interruptible: true
 
 test-unit:
   stage: test


### PR DESCRIPTION
Setzt Punkt 1 und 2 aus der Analyse zu #1133 um.

## Problem

Jeder Push erzeugt **zwei** Pipelines für denselben Commit — `source=push` und `source=external_pull_request_event` (von GitHub gespiegelt), eine Sekunde auseinander auf derselben Ref. Beide fahren die vollen Test-Stages auf demselben Runner.

Das kostet nicht nur die Hälfte der Runner-Kapazität, es ist auch ein latenter Fehler: **beide schreiben denselben GitHub-Status-Kontext** `ci/gitlab/scm.cms.hu-berlin.de`. Wer zuletzt fertig wird, entscheidet, ob ein PR grün aussieht.

Belege:
- Commit `2705e66b`: Pipeline 97383 grün, Pipeline 97384 rot — identischer Code
- Commit `da13012b`: beide Zwillinge posten in denselben Kontext, 83 s auseinander (`15:41:32` von 97426, `15:42:55` von 97427)

Und es ist der Druck auf dem Runner, der den `test-e2e`-Job beim Hochfahren der Dev-Server in den Timeout laufen lässt (vier `ng serve`-Prozesse plus zwei Chrome-Instanzen gleichzeitig).

## Änderung

```yaml
workflow:
  auto_cancel:
    on_new_commit: interruptible
  rules:
    - if: $CI_COMMIT_TAG
    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != "develop" && $CI_COMMIT_BRANCH != "master"
      when: never
    - when: always
```

- **`workflow:rules`** verwirft die Push-Pipeline auf Feature-Branches. Die PR-Pipeline bleibt, weil der Pflichtstatus auf sie verlinkt. Die Regeln sind absichtlich eng formuliert: Pushes auf `develop` und `master`, Tags, geplante und manuell gestartete Pipelines laufen unverändert weiter.
- **`workflow:auto_cancel` + `default:interruptible`** lassen eine Pipeline für einen neueren Commit eine noch laufende auf derselben Ref abbrechen, statt beide um den Runner konkurrieren zu lassen. Der YAML-Weg macht die Projekteinstellung „Auto-cancel redundant pipelines" unnötig.

## Bewusste Folge

**Ein Branch ohne offenen PR bekommt keine Pipeline mehr.** Ein Push-Pipeline kann nicht erkennen, ob zu ihrem Branch ein PR offen ist (`CI_EXTERNAL_PULL_REQUEST_IID` ist dort nicht gesetzt), der Kompromiss ist also unvermeidbar. Wer WIP pusht, sieht CI erst, sobald der PR existiert. Der Merge hängt ohnehin am PR-Status.

## Verifikation

Dieser PR prüft sich selbst: Beim Push des Branches (noch ohne PR) darf **keine** Pipeline entstehen, nach dem Öffnen des PRs genau **eine** — die mit `source=external_pull_request_event`. Ergebnis wird unten als Kommentar nachgetragen.

Nach dem Merge wird geprüft, dass `develop` weiterhin eine Pipeline bekommt und diese grün ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
