### PR TITLE
Unit-Tests für die abstrakten Element-Basisklassen (#1120)

### DIFF
--- a/projects/common/directives/compound-element.directive.spec.ts
+++ b/projects/common/directives/compound-element.directive.spec.ts
@@ -1,0 +1,58 @@
+import { ElementRef, QueryList } from '@angular/core';
+import { UIElement } from 'common/models/elements/element';
+import { CompoundElementComponent } from './compound-element.directive';
+import { ElementComponent } from './element-component.directive';
+
+/* The base class of the elements that contain other elements (cloze, likert, table). Its whole job
+   is to hand its form-element children upwards once the view exists, so the unit can register them
+   in the parent form. Both members it relies on are abstract, so the subclass supplies them. */
+class TestCompoundElementComponent extends CompoundElementComponent {
+  elementModel: UIElement = { id: 'compound_1' } as unknown as UIElement;
+  compoundChildren: QueryList<ElementComponent> = new QueryList<ElementComponent>();
+  children: ElementComponent[] = [];
+
+  getFormElementChildrenComponents(): ElementComponent[] {
+    return this.children;
+  }
+}
+
+describe('CompoundElementComponent', () => {
+  let component: TestCompoundElementComponent;
+  let emitted: ElementComponent[][];
+
+  const childComponent = (id: string): ElementComponent => (
+    { elementModel: { id } } as unknown as ElementComponent
+  );
+
+  beforeEach(() => {
+    component = new TestCompoundElementComponent(new ElementRef(document.createElement('div')));
+    emitted = [];
+    component.childrenAdded.subscribe(children => emitted.push(children));
+  });
+
+  it('should emit its form element children once the view exists', () => {
+    component.children = [childComponent('child_1'), childComponent('child_2')];
+
+    component.ngAfterViewInit();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].map(child => child.elementModel.id)).toEqual(['child_1', 'child_2']);
+  });
+
+  /* Still emits for a compound without form element children - a cloze that holds nothing but text
+     has none. The receiver has to cope with an empty list rather than with no event. */
+  it('should emit an empty list when there are no form element children', () => {
+    component.ngAfterViewInit();
+
+    expect(emitted).toEqual([[]]);
+  });
+
+  it('should emit exactly what getFormElementChildrenComponents returns', () => {
+    const children = [childComponent('child_1')];
+    component.children = children;
+
+    component.ngAfterViewInit();
+
+    expect(emitted[0]).toBe(children);
+  });
+});

--- a/projects/common/directives/element-component.directive.spec.ts
+++ b/projects/common/directives/element-component.directive.spec.ts
@@ -1,0 +1,97 @@
+import { ElementRef } from '@angular/core';
+import { AspectError } from 'common/classes/aspect-error';
+import { UIElement } from 'common/models/elements/element';
+import { ElementComponent } from './element-component.directive';
+
+/* The base class of every element component. It is abstract and has no template, so a minimal
+   subclass over a real DOM node is enough - `project` is decided by where that node sits, which is
+   the one thing here that needs an actual document. */
+class TestElementComponent extends ElementComponent {
+  elementModel: UIElement = { id: 'element_1' } as unknown as UIElement;
+}
+
+describe('ElementComponent', () => {
+  let host: HTMLElement;
+
+  const componentOn = (node: HTMLElement): TestElementComponent => new TestElementComponent(
+    new ElementRef(node)
+  );
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    host.remove();
+  });
+
+  it('should expose the host node as its dom element', () => {
+    expect(componentOn(host).domElement).toBe(host);
+  });
+
+  /* This is how the shared components tell the two apps apart: the player renders them inside
+     <aspect-unit>, the editor does not. */
+  it('should report the project as player when rendered inside a unit', () => {
+    const unit = document.createElement('aspect-unit');
+    unit.appendChild(host);
+    document.body.appendChild(unit);
+    const component = componentOn(host);
+
+    component.ngAfterContentChecked();
+
+    expect(component.project).toBe('player');
+    unit.remove();
+  });
+
+  it('should report the project as editor when rendered outside a unit', () => {
+    const component = componentOn(host);
+
+    component.ngAfterContentChecked();
+
+    expect(component.project).toBe('editor');
+  });
+
+  // closest() matches the node itself too, not only its ancestors.
+  it('should report the project as player when the host is the unit itself', () => {
+    const unit = document.createElement('aspect-unit');
+    document.body.appendChild(unit);
+    const component = componentOn(unit);
+
+    component.ngAfterContentChecked();
+
+    expect(component.project).toBe('player');
+    unit.remove();
+  });
+
+  /* Re-evaluated on every content check, so a node that gets moved is not stuck with the project it
+     was first rendered in. */
+  it('should re-evaluate the project when the host moves into a unit', () => {
+    const component = componentOn(host);
+    component.ngAfterContentChecked();
+    expect(component.project).toBe('editor');
+
+    const unit = document.createElement('aspect-unit');
+    document.body.appendChild(unit);
+    unit.appendChild(host);
+    component.ngAfterContentChecked();
+
+    expect(component.project).toBe('player');
+    unit.remove();
+  });
+
+  it('should throw an AspectError carrying code and message', () => {
+    const component = componentOn(host);
+
+    expect(() => component.throwError('MEDIA_TIMEOUT', 'Failed to load in time'))
+      .toThrowError(AspectError);
+    try {
+      component.throwError('MEDIA_TIMEOUT', 'Failed to load in time');
+      expect.unreachable('throwError did not throw');
+    } catch (error) {
+      expect((error as AspectError).code).toBe('MEDIA_TIMEOUT');
+      expect((error as AspectError).message).toBe('Failed to load in time');
+      expect((error as AspectError).name).toBe('AspectError');
+    }
+  });
+});

--- a/projects/common/directives/form-element-component.directive.spec.ts
+++ b/projects/common/directives/form-element-component.directive.spec.ts
@@ -1,0 +1,81 @@
+import { ElementRef } from '@angular/core';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { UIElement } from 'common/models/elements/element';
+import { FormElementComponent } from './form-element-component.directive';
+
+/* Abstract and without a template, so a minimal subclass is enough. What is worth pinning down here
+   is which of the two form controls a component ends up with: the one the parent form already holds
+   for its id, or a fresh one seeded from the element's value. In the player the parent form always
+   exists; in the editor it does not, and the element still has to be editable. */
+class TestFormElementComponent extends FormElementComponent {
+  elementModel: UIElement = { id: 'element_1', value: 'aus dem Modell' } as unknown as UIElement;
+}
+
+describe('FormElementComponent', () => {
+  const createComponent = (): TestFormElementComponent => new TestFormElementComponent(
+    new ElementRef(document.createElement('div'))
+  );
+
+  it('should take the control the parent form holds for the element id', () => {
+    const component = createComponent();
+    const existingControl = new UntypedFormControl('aus dem Formular');
+    component.parentForm = new UntypedFormGroup({ element_1: existingControl });
+
+    component.ngOnInit();
+
+    expect(component.elementFormControl).toBe(existingControl);
+    expect(component.elementFormControl.value).toBe('aus dem Formular');
+  });
+
+  it('should create a control from the element value when there is no parent form', () => {
+    const component = createComponent();
+
+    component.ngOnInit();
+
+    expect(component.elementFormControl).toBeInstanceOf(UntypedFormControl);
+    expect(component.elementFormControl.value).toBe('aus dem Modell');
+  });
+
+  /* Characterizes an edge the concrete components never hit: with a parent form that has no control
+     under this id, the lookup yields undefined and no fallback control is created. setElementValue
+     would then fail. Recorded, not endorsed. */
+  it('should leave the control undefined when the parent form does not know the element', () => {
+    const component = createComponent();
+    component.parentForm = new UntypedFormGroup({ another_element: new UntypedFormControl('x') });
+
+    component.ngOnInit();
+
+    expect(component.elementFormControl).toBeUndefined();
+  });
+
+  it('should write a new value into the control', () => {
+    const component = createComponent();
+    component.ngOnInit();
+
+    component.setElementValue('neuer Wert');
+
+    expect(component.elementFormControl.value).toBe('neuer Wert');
+  });
+
+  /* The second parameter exists for subclasses that need it (a cloze child passes its index, for
+     example); the base implementation ignores it. */
+  it('should ignore the option parameter', () => {
+    const component = createComponent();
+    component.ngOnInit();
+
+    component.setElementValue('neuer Wert', 3);
+
+    expect(component.elementFormControl.value).toBe('neuer Wert');
+  });
+
+  it('should write through to the control the parent form owns', () => {
+    const component = createComponent();
+    const existingControl = new UntypedFormControl('alt');
+    component.parentForm = new UntypedFormGroup({ element_1: existingControl });
+    component.ngOnInit();
+
+    component.setElementValue('neu');
+
+    expect(existingControl.value).toBe('neu');
+  });
+});

--- a/projects/common/directives/media-player-element-component.directive.spec.ts
+++ b/projects/common/directives/media-player-element-component.directive.spec.ts
@@ -1,0 +1,152 @@
+import { ElementRef } from '@angular/core';
+import { Subject } from 'rxjs';
+import { AudioElement } from 'common/models/elements/media-player-group-elements/audio';
+import { MediaPlayerElementComponent } from './media-player-element-component.directive';
+
+/* The base class of the audio and video components. It carries the two pieces of cross-element state
+   that a single media component cannot know on its own:
+   - `active`: only one media element may play at a time, so it listens for who is playing
+   - `dependencyDissolved`: an element can be configured to stay locked until another one has been
+     played (`player.activeAfterID`), so it listens for elements reporting that they finished
+
+   Both arrive through subjects the unit owns. Neither input is guaranteed - the editor renders these
+   components without them - so the subscriptions are conditional. */
+class TestMediaPlayerElementComponent extends MediaPlayerElementComponent {
+  elementModel: AudioElement;
+
+  constructor(id: string, activeAfterID: string = '', alias: string = 'Ton', fileName: string = 'ton.mp3') {
+    super(new ElementRef(document.createElement('div')));
+    this.elementModel = {
+      id, alias, fileName, player: { activeAfterID }
+    } as unknown as AudioElement;
+  }
+}
+
+describe('MediaPlayerElementComponent', () => {
+  let actualPlayingId: Subject<string | null>;
+  let mediaStatusChanged: Subject<string>;
+
+  const initComponent = (component: TestMediaPlayerElementComponent): TestMediaPlayerElementComponent => {
+    component.actualPlayingId = actualPlayingId;
+    component.mediaStatusChanged = mediaStatusChanged;
+    component.ngOnInit();
+    return component;
+  };
+
+  beforeEach(() => {
+    actualPlayingId = new Subject<string | null>();
+    mediaStatusChanged = new Subject<string>();
+  });
+
+  it('should start out active and not yet loaded', () => {
+    const component = new TestMediaPlayerElementComponent('audio_1');
+
+    expect(component.active).toBe(true);
+    expect(component.isLoaded.value).toBe(false);
+  });
+
+  describe('dependency on another element', () => {
+    it('should start dissolved when the element does not wait for another one', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1'));
+
+      expect(component.dependencyDissolved).toBe(true);
+    });
+
+    it('should start undissolved when the element waits for another one', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1', 'audio_2'));
+
+      expect(component.dependencyDissolved).toBe(false);
+    });
+
+    it('should dissolve the dependency when the awaited element reports in', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1', 'audio_2'));
+
+      mediaStatusChanged.next('audio_2');
+
+      expect(component.dependencyDissolved).toBe(true);
+    });
+
+    it('should keep waiting when another element reports in', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1', 'audio_2'));
+
+      mediaStatusChanged.next('audio_3');
+
+      expect(component.dependencyDissolved).toBe(false);
+    });
+
+    /* Once dissolved it stays dissolved - the guard in setActivatedAfterID exists for exactly this,
+       so a later report from a different element cannot lock the media again. */
+    it('should not re-lock once the dependency is dissolved', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1', 'audio_2'));
+      mediaStatusChanged.next('audio_2');
+
+      mediaStatusChanged.next('audio_3');
+
+      expect(component.dependencyDissolved).toBe(true);
+    });
+  });
+
+  describe('only one element playing at a time', () => {
+    it('should go inactive while another element is playing', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1'));
+
+      actualPlayingId.next('audio_2');
+
+      expect(component.active).toBe(false);
+    });
+
+    it('should stay active while it is the one playing', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1'));
+
+      actualPlayingId.next('audio_1');
+
+      expect(component.active).toBe(true);
+    });
+
+    it('should become active again when nothing is playing', () => {
+      const component = initComponent(new TestMediaPlayerElementComponent('audio_1'));
+      actualPlayingId.next('audio_2');
+
+      actualPlayingId.next(null);
+
+      expect(component.active).toBe(true);
+    });
+  });
+
+  /* The editor renders these components without the unit's subjects, so ngOnInit has to cope with
+     both inputs being absent. */
+  it('should initialise without the unit subjects', () => {
+    const component = new TestMediaPlayerElementComponent('audio_1', 'audio_2');
+
+    expect(() => component.ngOnInit()).not.toThrow();
+    expect(component.dependencyDissolved).toBe(false);
+    expect(component.active).toBe(true);
+  });
+
+  it('should stop listening to both subjects when destroyed', () => {
+    const component = initComponent(new TestMediaPlayerElementComponent('audio_1', 'audio_2'));
+
+    component.ngOnDestroy();
+    actualPlayingId.next('audio_2');
+    mediaStatusChanged.next('audio_2');
+
+    expect(component.active).toBe(true);
+    expect(component.dependencyDissolved).toBe(false);
+  });
+
+  describe('error messages', () => {
+    it('should name alias and file in the timeout message', () => {
+      const component = new TestMediaPlayerElementComponent('audio_1', '', 'Hörtext 1', 'hoertext.mp3');
+
+      expect(component.timeoutMsg)
+        .toBe('Failed to load media element with alias "Hörtext 1" and filename "hoertext.mp3" in time');
+    });
+
+    it('should name alias and file in the missing duration message', () => {
+      const component = new TestMediaPlayerElementComponent('audio_1', '', 'Hörtext 1', 'hoertext.mp3');
+
+      expect(component.mediaDurationNotAvailableMsg)
+        .toBe('Media duration of element with alias "Hörtext 1" and filename "hoertext.mp3" is not available');
+    });
+  });
+});


### PR DESCRIPTION
Follow-up zu #1114: die vier abstrakten Basisklassen mit eigener Logik hatten keine eigene Spec — ihre Logik lief nur beiläufig in den Specs der konkreten Komponenten mit, Randfälle gar nicht.

**Kein Produktivcode angefasst**, nur vier neue `.spec.ts`.

| Spec | Tests | Schwerpunkt |
| --- | --- | --- |
| `element-component.directive.spec.ts` | 6 | Projekterkennung (`player`/`editor`), `AspectError` aus `throwError` |
| `form-element-component.directive.spec.ts` | 6 | welches der zwei Form-Controls die Komponente bekommt |
| `compound-element.directive.spec.ts` | 3 | Weitergabe der Kinder nach `ngAfterViewInit` |
| `media-player-element-component.directive.spec.ts` | 13 | `active` bei fremder Wiedergabe, `activeAfterID`-Abhängigkeit, Teardown |

## Kein Test-Host nötig

Das Ticket schlug „Test-Subklasse plus Test-Host" vor. Alle vier Klassen sind abstrakt **und ohne Template**, deshalb reicht eine minimale Test-Subklasse; nur `ElementComponent` braucht überhaupt das Dokument (`closest(aspect-unit)`), und dafür genügt ein echter DOM-Knoten ohne TestBed. Ein Host hätte Angulars Lifecycle-Aufrufe geprüft, nicht die Logik der Klassen.

## Zwei Randfälle, die kein konkretes Element erreicht

- **`FormElementComponent`**: liegt ein Elternformular vor, das aber **kein** Control unter dieser Element-ID hat, bleibt `elementFormControl` `undefined` — `setElementValue` würde danach scheitern. Als Charakterisierungstest festgehalten, nicht bewertet.
- **`CompoundElementComponent`**: ein Compound **ohne** Form-Element-Kinder emittiert trotzdem, nämlich eine leere Liste. Der Empfänger muss also mit einer leeren Liste umgehen, nicht mit einem fehlenden Ereignis.

## Wirksamkeit belegt

Fünf Mutationen, jede einzeln geprüft: `player`/`editor` vertauscht, Form-Control immer neu erzeugt, `if (!this.dependencyDissolved)`-Guard entfernt, `ngOnDestroy` geleert, Kinder nur bei nichtleerer Liste emittiert. Jede wird gefangen, jeweils von den Tests, die sie fangen sollen.

Nebenbefund: die indirekte Abdeckung war dünner als gedacht — die Projekterkennung hing an genau *einem* fremden Test (`TriggerComponent`), die Form-Control-Auswahl an drei, und die leere Compound-Liste an **keinem**.

## Bewusst ohne Spec

Wie im Ticket entschieden: `text-input-component` (nur Deklarationen), `base-tooltip` (über die zwei konkreten Tooltip-Direktiven abgedeckt), `APIService` (über die Fake-Implementierung in `external-resource.service.spec.ts`).

## Absicherung

Komplette Testkette grün: common 104/564 (vorher 100/536), player-modules 18/123, editor 96/601, editor-modules 32/159, player 64/572. Lint der neuen Dateien sauber.

Kein Changelog-Eintrag: keine neuen Properties oder Features.

Refs #1120 — bewusst **ohne** `Closes`, damit die Board-Karte beim Merge nicht auf „Done" springt, sondern bis zum Release auf „Zu Veröffentlichen" bleibt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)