### PR TITLE
Eigenschaften-Panel: zwei Absturz-/Datenverlustfehler bei Mehrfachauswahl (#1151, #1152)

### DIFF
--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -36,6 +36,7 @@ Editor
   - Lange Eingaben ohne Leerzeichen vergrößern das Element auf der Arbeitsfläche nicht mehr über den Abschnittsrand hinaus (überlange Formeln scrollen innerhalb des Feldes, Segmente im Formelbereich brechen um)
 - Eigenschaftenbereich bei gemeinsamer Markierung
   - Sind mehrere Elemente mit unterschiedlichen Optionslisten markiert, wird die Vorbelegung nicht mehr angeboten (verursachte bislang einen fortlaufenden Fehler in der Browser-Konsole)
+  - "Medienquelle ändern" wird bei Elementen unterschiedlichen Typs nicht mehr angeboten; ein Klick darauf löschte zuvor Bild und Dateinamen bei allen markierten Elementen
 
 ## 2.12.4
 ### Fehlerbehebungen 

--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -34,6 +34,8 @@ Editor
   - Korrigiert die Element-Auswahl nach dem Einfügen zweiseitiger Abschnittsvorlagen aus einem nachfolgenden Abschnitt
 - Formelfeld, Formelbereich
   - Lange Eingaben ohne Leerzeichen vergrößern das Element auf der Arbeitsfläche nicht mehr über den Abschnittsrand hinaus (überlange Formeln scrollen innerhalb des Feldes, Segmente im Formelbereich brechen um)
+- Eigenschaftenbereich bei gemeinsamer Markierung
+  - Sind mehrere Elemente mit unterschiedlichen Optionslisten markiert, wird die Vorbelegung nicht mehr angeboten (verursachte bislang einen fortlaufenden Fehler in der Browser-Konsole)
 
 ## 2.12.4
 ### Fehlerbehebungen 

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/media-source-properties/media-source-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/media-source-properties/media-source-properties.component.html
@@ -5,7 +5,9 @@
   </div>
 }
 
-@if (combinedProperties.src) {
+<!--`type != null` alongside the src: which file dialog to open follows from the element type, so a
+    selection of mixed types - whose type merges to null - has no dialog to offer. See #1152.-->
+@if (combinedProperties.src && combinedProperties.type != null) {
   <button class="media-src-button" [style.align-self]="'center'"
           mat-fab color="primary"
           [matTooltip]="'propertiesPanel.changeMediaSource' | translate" [matTooltipPosition]="'right'"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/media-source-properties/media-source-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/media-source-properties/media-source-properties.component.spec.ts
@@ -90,17 +90,26 @@ describe('MediaSourcePropertiesComponent', () => {
     ]);
   });
 
-  /* Characterizes what an unknown type does today: no branch matches, and the empty defaults are
-     emitted anyway - so choosing nothing clears the source. Recorded, not endorsed. */
-  it('should emit empty values for an element type it has no file dialog for', async () => {
+  /* No branch matches, so there is no file to write - and writing the empty defaults would clear
+     the source of every selected element instead (#1152). */
+  it('should emit nothing for an element type it has no file dialog for', async () => {
     const emitted: { property: string; value: unknown }[] = [];
     component.updateModel.subscribe(update => emitted.push(update));
 
     await component.changeMediaSrc('text-field');
 
-    expect(emitted).toEqual([
-      { property: 'src', value: '' },
-      { property: 'fileName', value: '' }
-    ]);
+    expect(emitted).toEqual([]);
+  });
+
+  /* The type of a selection of mixed element types merges to null, and the dialog to open follows
+     from the type - so the panel does not offer the button in the first place (#1152). */
+  it('should hide the source button when the element types disagree', () => {
+    component.combinedProperties = {
+      type: null, fileName: 'bild.png', src: 'data:image/png;base64,abc'
+    };
+    fixture.detectChanges();
+
+    expect(fileName()).not.toBeNull();
+    expect(sourceButton()).toBeNull();
   });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/media-source-properties/media-source-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/media-source-properties/media-source-properties.component.ts
@@ -11,7 +11,8 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
 
 /**
  * What this component reads. `type` is not part of the media source: it decides which file dialog
- * to open, because the four media elements accept different formats.
+ * to open, because the four media elements accept different formats — and therefore also whether
+ * the replace button can be offered at all.
  *
  * Geometry has `fileName` without `src` — that is why the two live on separate levels in the model
  * (`FileNameProperties`, and `MediaSourceProperties` extending it), and why each control here has
@@ -57,6 +58,10 @@ export class MediaSourcePropertiesComponent {
         break;
       // no default
     }
+    /* No branch produced a file - an element type without a dialog, or one of the dialogs above
+       returning nothing. Emitting the empty defaults here would clear the source of every selected
+       element without ever having asked for a replacement (#1152). */
+    if (!media.name) return;
     this.updateModel.emit({ property: 'src', value: media.content });
     this.updateModel.emit({ property: 'fileName', value: media.name });
   }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.html
@@ -14,21 +14,26 @@
          (input)="updateModel.emit({property: 'value', value: valueField2.value })">
 </mat-form-field>
 
-<mat-form-field *ngIf="combinedProperties.options !== undefined && combinedProperties.rows === undefined"
-                appearance="fill" class="wide-form-field">
-  <mat-label>{{'preset' | translate }}</mat-label>
-  <mat-select [value]="combinedProperties.value"
-              (selectionChange)="updateModel.emit({ property: 'value', value: $event.value })">
-    <mat-select-trigger [innerHTML]="combinedProperties.value !== undefined && combinedProperties.value !== null ?
-                                     $any(combinedProperties.options)[$any(combinedProperties.value)].text :
-                                     ''">
-    </mat-select-trigger>
-    <mat-option [value]="null">{{'propertiesPanel.undefined' | translate }}</mat-option>
-    <mat-option *ngFor="let option of $any(combinedProperties.options); let i = index" [value]="i">
-      <div [innerHTML]="option.text + ' (Index: ' + i + ')' | safeResourceHTML"></div>
-    </mat-option>
-  </mat-select>
-</mat-form-field>
+<!--dropdown, radio-button-group and the like. `!= null` rather than `!== undefined`: a selection
+    whose option lists disagree merges to null, and then there are no options to pick a preset from -
+    the trigger below would index into null on every change detection cycle. `rows === undefined`
+    excludes the likert, which has options but no single preset.-->
+@if (combinedProperties.options != null && combinedProperties.rows === undefined) {
+  <mat-form-field appearance="fill" class="wide-form-field">
+    <mat-label>{{'preset' | translate }}</mat-label>
+    <mat-select [value]="combinedProperties.value"
+                (selectionChange)="updateModel.emit({ property: 'value', value: $event.value })">
+      <mat-select-trigger [innerHTML]="combinedProperties.options | presetOptionText:combinedProperties.value">
+      </mat-select-trigger>
+      <mat-option [value]="null">{{'propertiesPanel.undefined' | translate }}</mat-option>
+      @for (option of combinedProperties.options; track $index) {
+        <mat-option [value]="$index">
+          <div [innerHTML]="option.text + ' (Index: ' + $index + ')' | safeResourceHTML"></div>
+        </mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+}
 
 <ng-container *ngIf="combinedProperties.type === 'math-field'">
   <div style="display: flex; justify-content: space-between; align-items: center;">

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.spec.ts
@@ -13,6 +13,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { MathKeyboardPreset } from 'common/models/input-element-interfaces';
 import { SafeResourceHTMLPipe } from 'common/pipes/safe-resource-html.pipe';
+import { PresetOptionTextPipe } from 'editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe';
 import {
   PresetValuePropertiesComponent
 } from './preset-value-properties.component';
@@ -36,6 +37,7 @@ describe('PresetValuePropertiesComponent', () => {
       declarations: [
         PresetValuePropertiesComponent,
         MockMathInputComponent,
+        PresetOptionTextPipe,
         SafeResourceHTMLPipe
       ],
       imports: [
@@ -84,6 +86,26 @@ describe('PresetValuePropertiesComponent', () => {
     optionSelect.triggerEventHandler('selectionChange', { value: 1 });
 
     expect(emitted).toEqual([{ property: 'value', value: 1 }]);
+  });
+
+  /* Option lists that disagree across the selection merge to null, while a preset index shared by
+     the elements survives. Offering the select then meant indexing into null - on every change
+     detection cycle, because the trigger renders in the closed state too (#1151). */
+  it('should not offer the select when the option lists disagree', () => {
+    component.combinedProperties = { type: 'dropdown', value: 0, options: null };
+
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(fixture.debugElement.query(By.css('mat-select'))).toBeNull();
+  });
+
+  // The likert has options but no single preset of its own, so it keeps the select away.
+  it('should not offer the select for an element with option rows', () => {
+    component.combinedProperties = {
+      type: 'likert', options: [{ text: 'A' }], rows: []
+    };
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('mat-select'))).toBeNull();
   });
 
   it('should emit the value of the math input', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.spec.ts
@@ -8,7 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
+import { MatSelect, MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { MathKeyboardPreset } from 'common/models/input-element-interfaces';
@@ -88,6 +88,34 @@ describe('PresetValuePropertiesComponent', () => {
     expect(emitted).toEqual([{ property: 'value', value: 1 }]);
   });
 
+  /* The closed select shows the preset's text, and the option it names can be renamed while the
+     panel stays open. The merge hands down the element's own option array (`{...elements[0]}`) and
+     `UIElement.setProperty` splices into it to keep the reference intact, so that rename reaches
+     the trigger as an in-place mutation - nothing the binding could be keyed on changes. */
+  it('should follow a renamed option in the closed select', async () => {
+    const options = [{ text: 'A' }, { text: 'B' }];
+    component.combinedProperties = { type: 'dropdown', value: 1, options };
+    fixture.detectChanges();
+
+    /* MatSelect keeps its options in the overlay and renders the custom trigger only once
+       something is selected, so the preset has to be picked up before the trigger exists. */
+    const select = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+    select.open();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    select.close();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const trigger = () => fixture.debugElement.query(By.css('mat-select-trigger')).nativeElement;
+    expect(trigger().textContent).toBe('B');
+
+    options[1].text = 'B neu';
+    fixture.detectChanges();
+
+    expect(trigger().textContent).toBe('B neu');
+  });
+
   /* Option lists that disagree across the selection merge to null, while a preset index shared by
      the elements survives. Offering the select then meant indexing into null - on every change
      detection cycle, because the trigger renders in the closed state too (#1151). */
@@ -98,7 +126,9 @@ describe('PresetValuePropertiesComponent', () => {
     expect(fixture.debugElement.query(By.css('mat-select'))).toBeNull();
   });
 
-  // The likert has options but no single preset of its own, so it keeps the select away.
+  /* The likert has options but no single preset of its own. `PANEL_SECTIONS` does not route it to
+     this component today, so the clause is a belt-and-braces one - pinned down so that giving the
+     likert a preset section cannot quietly hand it a control it has no property for. */
   it('should not offer the select for an element with option rows', () => {
     component.combinedProperties = {
       type: 'likert', options: [{ text: 'A' }], rows: []

--- a/projects/editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe.spec.ts
@@ -1,0 +1,33 @@
+import { PresetOptionTextPipe } from 'editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe';
+
+describe('PresetOptionTextPipe', () => {
+  const pipe = new PresetOptionTextPipe();
+  const options = [{ text: 'Erste' }, { text: 'Zweite' }];
+
+  it('should return the text of the option the index points at', () => {
+    expect(pipe.transform(options, 0)).toBe('Erste');
+    expect(pipe.transform(options, 1)).toBe('Zweite');
+  });
+
+  it('should return an empty string when no preset is chosen', () => {
+    expect(pipe.transform(options, null)).toBe('');
+    expect(pipe.transform(options, undefined)).toBe('');
+  });
+
+  /* The option lists of the selected elements disagree, so the merge has no answer - #1151. The
+     preset index can survive that merge, which is what used to make the lookup throw. */
+  it('should return an empty string for option lists that merged to null', () => {
+    expect(pipe.transform(null, 0)).toBe('');
+  });
+
+  it('should return an empty string for an index outside the option list', () => {
+    expect(pipe.transform(options, 2)).toBe('');
+    expect(pipe.transform(options, -1)).toBe('');
+  });
+
+  // A preset is an index; anything else the value union allows is not one to look up.
+  it('should return an empty string for a value that is not an index', () => {
+    expect(pipe.transform(options, 'Erste')).toBe('');
+    expect(pipe.transform(options, ['Erste'])).toBe('');
+  });
+});

--- a/projects/editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe.ts
+++ b/projects/editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe.ts
@@ -10,9 +10,17 @@ import { TextLabel } from 'common/models/label-interfaces';
  * option lists that disagree across the selection (`null`), and an index left over from a shorter
  * list. The trigger renders on every change detection cycle, so a lookup that throws throws
  * repeatedly - see #1151.
+ *
+ * Impure on purpose, against the preference for pure pipes in rules.md 2. The panel hands down the
+ * element's own option array (`mergeElements` shallow-copies the element) and `UIElement.setProperty`
+ * splices into arrays to keep their reference intact, so renaming, removing or reordering an option
+ * reaches this pipe as an in-place mutation: a pure pipe would never see it and the closed select
+ * would keep naming the option's old text. One index lookup per cycle is what the inline expression
+ * this replaced cost anyway.
  */
 @Pipe({
   name: 'presetOptionText',
+  pure: false,
   standalone: false
 })
 export class PresetOptionTextPipe implements PipeTransform {

--- a/projects/editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe.ts
+++ b/projects/editor/src/app/modules/properties-panel/pipes/preset-option-text.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { InputElementValue } from 'common/models/input-element-interfaces';
+import { TextLabel } from 'common/models/label-interfaces';
+
+/**
+ * The text of the preset option, for the closed state of the preset select.
+ *
+ * The select stores the preset as an index into the option list, so the label has to be looked up.
+ * Everything that is not an index the list actually holds yields the empty string: no preset chosen,
+ * option lists that disagree across the selection (`null`), and an index left over from a shorter
+ * list. The trigger renders on every change detection cycle, so a lookup that throws throws
+ * repeatedly - see #1151.
+ */
+@Pipe({
+  name: 'presetOptionText',
+  standalone: false
+})
+export class PresetOptionTextPipe implements PipeTransform {
+  // eslint-disable-next-line class-methods-use-this
+  transform(options: TextLabel[] | null | undefined, value: InputElementValue | undefined): string {
+    if (options == null || typeof value !== 'number') return '';
+    return options[value]?.text ?? '';
+  }
+}

--- a/projects/editor/src/app/modules/properties-panel/properties-panel.module.ts
+++ b/projects/editor/src/app/modules/properties-panel/properties-panel.module.ts
@@ -95,6 +95,7 @@ import {
   OptionsFieldSetComponent
 } from './components/element-model-properties/options-field-set/options-field-set.component';
 import { PositionFieldSetComponent } from './components/position-field-set/position-field-set.component';
+import { PresetOptionTextPipe } from './pipes/preset-option-text.pipe';
 import {
   PresetValuePropertiesComponent
 } from './components/element-model-properties/preset-value-properties/preset-value-properties.component';
@@ -138,7 +139,7 @@ import {
  *
  * Only ElementPropertiesPanelComponent is exported. The other 37 components are internal to
  * this module on purpose: the panel's structure can then be reworked without checking the rest of
- * the editor for usages. The four pipes are used by this module's templates only.
+ * the editor for usages. The five pipes are used by this module's templates only.
  *
  * This module deliberately lives under src/app rather than under editor/modules/. It is not a
  * self-contained unit — its components reach for the editor's root-provided services
@@ -193,6 +194,7 @@ import {
     GetStateVariablePipe,
     GetValidDropListsPipe,
     LikertRowLabelPipe,
+    PresetOptionTextPipe,
     ScrollPageIndexPipe
   ],
   imports: [


### PR DESCRIPTION
Zwei vorbestehende Fehler bei Mehrfachauswahl, beide beim Review des Panel-Umbaus (#1137) gefunden
und dort bewusst zurückgestellt. Gleiche Klasse: der Merge antwortet „die markierten Elemente sind
sich uneinig" mit `null`, und das Panel behandelte `null` wie einen gültigen Wert.

**Noch nicht im laufenden Editor gesichtet** — siehe die Liste unten.

## #1151 — Vorbelegung bei uneinigen Optionslisten

Das Gate fragte `options !== undefined`. Zwei Klapplisten mit *verschiedenen* Optionslisten und
*gleichem* Vorbelegungsindex rendern das Control also: `options` ist `null`, `value` hat den Merge
überlebt, der Trigger indiziert in `null`. Der Trigger rendert auch im geschlossenen Zustand,
deshalb wiederholte sich der `TypeError` bei jedem Change-Detection-Zyklus, solange das Panel offen
war. Betroffen war jeder Elementtyp mit Optionsliste und Vorbelegung.

`!= null` ist die Regel, die `options-field-set` seit #1137 hält: wo der Merge keine Antwort
hergibt, bietet das Panel kein Control an.

Der Lookup selbst ist in eine Pipe gewandert. Der verschachtelte Ternary mit zwei `$any()` war der
Grund, warum der Compiler die Indizierung nicht sah; als Pipe ist sie typisiert, getestet und
liefert für alles, was kein Index der Liste ist, den leeren String — ein Index aus einer kürzeren
Liste kann damit auch nicht mehr werfen. Der Block konnte dadurch auf `@if`/`@for` umgestellt
werden und ist cast-frei (rules.md 2, 8, 10).

## #1152 — „Medienquelle ändern" bei gemischter Auswahl

`changeMediaSrc` wählt den Dateidialog über den Elementtyp. Bei Bild + Hotspot-Bild mit derselben
Datei merged `type` zu `null`, kein `case` trifft, `media` behält seine Leerwerte — und die beiden
Emits am Ende liefen unbedingt. Ein Klick öffnete also keinen Dialog und löschte stattdessen Quelle
und Dateiname bei allen markierten Elementen.

Beide vom Ticket vorgeschlagenen Hälften, weil sie unterschiedliche Wege abdecken:

- Der Knopf ist zusätzlich auf `type != null` gegated — kein Control ohne Dialog.
- `changeMediaSrc` bricht ab, bevor es schreibt, wenn kein Zweig eine Datei erzeugt hat. Das deckt
  auch jeden anderen Weg zu einem leeren `media` ab.

Der Charakterisierungs-Test, der das alte Verhalten festhielt („recorded, not endorsed"), prüft
jetzt, dass nichts emittiert wird.

## Ein dritter Commit: Regression aus dem ersten, im Review gefunden

Die Pipe war zunächst **pure** — und fror damit das Label des geschlossenen Selects ein. Der Grund
steckt zwei Ebenen tiefer:

- `mergeElements()` macht `{ ...elements[0] }`, `combinedProperties.options` **ist** also das Array
  des Elements. (`rows` wird in `createCombinedProperties` ausdrücklich mit `[...]` kopiert,
  `options` nicht.)
- `UIElement.setProperty()` splict in Arrays hinein — Kommentar dort: „keep array reference intact".

Eine Option umbenennen ist damit eine In-place-Mutation: weder Array-Referenz noch Preset-Index
ändern sich, die pure Pipe läuft nie erneut. Das Label nannte den alten Text, bis das Element ab-
und wieder angewählt wurde; nach Entfernen oder Umsortieren nannte es die falsche Option. Der
ersetzte Inline-Ausdruck wurde jeden Zyklus neu ausgewertet und hatte das Problem nicht.

Behoben mit `pure: false`, bewusst gegen rules.md 2 und mit der Begründung im Doc-Kommentar der
Pipe. Kosten: ein Array-Zugriff pro Zyklus — genau das, was der ersetzte Ausdruck kostete.

## Bitte im laufenden Editor ansehen

1. **Zwei Klapplisten, verschiedene Optionen, gleiche Vorbelegung, beide markiert.** Konsole muss
   still bleiben; das Feld „Vorbelegung" wird nicht angeboten.
2. **Bild + Hotspot-Bild mit derselben Datei, beide markiert.** „Medienquelle ändern" darf gar nicht
   erst erscheinen; Bild und Dateiname bleiben erhalten.
3. **Eine Klappliste mit Vorbelegung, Option im Optionen-Panel umbenennen.** Das Feld „Vorbelegung"
   muss den neuen Text sofort mitziehen — das ist die Regression aus dem dritten Commit.

## Absicherung

- `ng test editor`: 755 Tests grün (104 Dateien). Das Charakterisierungsnetz (240 Tests) unverändert
  grün, die Baseline hat sich nicht bewegt.
- `ng build editor` sauber, ESLint auf dem Panel-Modul ohne Errors (4 vorbestehende `any`-Warnungen
  in fremden Dateien).
- Jeder der drei Commits hat einen ausgeführten Gegencheck. Für #1151 fällt der neue Test mit dem
  alten Gate und Trigger als `TypeError: Cannot read properties of null (reading '0')` — der
  gemeldete Fehler wörtlich.

Refs #1151, refs #1152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
