### PR TITLE
Tote Likert-Klausel aus dem Vorbelegungs-Gate entfernen (#1158)

### DIFF
--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.html
@@ -16,9 +16,8 @@
 
 <!--dropdown, radio-button-group and the like. `!= null` rather than `!== undefined`: a selection
     whose option lists disagree merges to null, and then there are no options to pick a preset from -
-    the trigger below would index into null on every change detection cycle. `rows === undefined`
-    excludes the likert, which has options but no single preset.-->
-@if (combinedProperties.options != null && combinedProperties.rows === undefined) {
+    the trigger below would index into null on every change detection cycle.-->
+@if (combinedProperties.options != null) {
   <mat-form-field appearance="fill" class="wide-form-field">
     <mat-label>{{'preset' | translate }}</mat-label>
     <mat-select [value]="combinedProperties.value"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.spec.ts
@@ -126,18 +126,6 @@ describe('PresetValuePropertiesComponent', () => {
     expect(fixture.debugElement.query(By.css('mat-select'))).toBeNull();
   });
 
-  /* The likert has options but no single preset of its own. `PANEL_SECTIONS` does not route it to
-     this component today, so the clause is a belt-and-braces one - pinned down so that giving the
-     likert a preset section cannot quietly hand it a control it has no property for. */
-  it('should not offer the select for an element with option rows', () => {
-    component.combinedProperties = {
-      type: 'likert', options: [{ text: 'A' }], rows: []
-    };
-    fixture.detectChanges();
-
-    expect(fixture.debugElement.query(By.css('mat-select'))).toBeNull();
-  });
-
   it('should emit the value of the math input', () => {
     component.combinedProperties = { type: 'math-field', value: '1+1' };
     fixture.detectChanges();

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/preset-value-properties/preset-value-properties.component.ts
@@ -2,7 +2,6 @@ import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
 import { DropdownProperties } from 'common/models/elements/input-group-elements/dropdown';
-import { LikertProperties } from 'common/models/elements/compound-group-elements/likert/likert';
 import { MathFieldProperties } from 'common/models/elements/text-input-group-elements/math-field';
 import { InputElementProperties, MathKeyboardProperties } from 'common/models/input-element-interfaces';
 import { UIElementProperties } from 'common/models/ui-element-interfaces';
@@ -12,14 +11,17 @@ import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-pr
  * The preset value of an input element, in the shape the element type calls for: a textarea, a
  * text field, a select over the options or the formula editor.
  *
- * Only `value` is written; the rest is read to pick that shape. `rows` is read solely to exclude
- * the likert, which has options but no single preset.
+ * Only `value` is written; the rest is read to pick that shape.
+ *
+ * Which element types get here at all is `PANEL_SECTIONS`' business, not this component's. It used
+ * to read `rows` as well, to keep the likert out - the likert has options but no single preset.
+ * Since #1137 the likert simply has no `presetValue` section, and `panelSectionsOf()` intersects
+ * for a multi-selection, so it cannot arrive here mixed with a dropdown either (#1158).
  */
 export type PanelPresetValueProperties =
   Pick<UIElementProperties, 'type'> &
   Pick<InputElementProperties, 'value'> &
   Pick<DropdownProperties, 'options'> &
-  Pick<LikertProperties, 'rows'> &
   Pick<MathFieldProperties, 'enableModeSwitch'> &
   Pick<MathKeyboardProperties, 'mathKeyboardPresets'>;
 

--- a/projects/editor/src/app/modules/properties-panel/models/panel-sections.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/models/panel-sections.spec.ts
@@ -52,6 +52,16 @@ describe('panelSectionsOf', () => {
       expect(show.options).toBe(false);
     });
 
+    /* The likert has an option list but no single preset, and this is the only thing keeping it
+       away from the preset control - `preset-value-properties` used to check `rows` itself, which
+       was dead weight once the map existed (#1158). Mixed with a dropdown it is the intersection
+       that decides, so this is where the guarantee lives. */
+    it('should not offer the preset to a likert, alone or mixed with a dropdown', () => {
+      expect(panelSectionsOf([element('likert')]).presetValue).toBe(false);
+      expect(panelSectionsOf([element('likert'), element('dropdown')]).presetValue).toBe(false);
+      expect(panelSectionsOf([element('dropdown')]).presetValue).toBe(true);
+    });
+
     it('should not care about the order of the selection', () => {
       expect(panelSectionsOf([element('radio'), element('dropdown')]))
         .toEqual(panelSectionsOf([element('dropdown'), element('radio')]));


### PR DESCRIPTION
Aufräumen, keine sichtbare Verhaltensänderung.

`combinedProperties.rows === undefined` im Gate des Vorbelegungs-Selects sollte den Likert
draußen halten — er hat eine Optionsliste, aber keine einzelne Vorbelegung. Seit #1137
entscheidet das `PANEL_SECTIONS`: der Likert bekommt keine `presetValue`-Sektion, und
`panelSectionsOf()` bildet bei Mehrfachauswahl die Schnittmenge, kommt also auch gemischt mit
einer Klappliste nicht dort an. Die Klausel war in jeder Kombination unerreichbar.

Aufgekommen im Review von #1151 als vermutete Lücke: `rows` überlebt den Merge nicht, wenn nur
eines der markierten Elemente es hat, ist also `undefined` statt `null` — die Klausel hätte eine
gemischte Auswahl durchgelassen. Nachgeprüft trägt das nicht, die Schnittmenge greift vorher. Der
Verdacht war falsch, die tote Klausel war echt.

`Pick<LikertProperties, 'rows'>` fällt mit weg; es stand nur für diesen einen Zugriff im Panel-Typ.

## Der Test wandert

Die Komponenten-Spec verliert den Test auf die Klausel, `panel-sections.spec.ts` bekommt an seiner
Stelle einen — dort, wo die Zusage heute wirklich liegt. Der neue Test deckt zusätzlich die
gemischte Auswahl ab, die die Komponente nie hätte prüfen können.

## Absicherung

- `ng test editor`: 755 Tests grün (104 Dateien), Charakterisierungsnetz unverändert.
- `ng build editor` sauber, ESLint auf dem Panel-Modul ohne Errors.
- **Gegencheck per Mutation:** gibt man dem Likert testweise die `presetValue`-Sektion, fällt der
  neue Test (`expected true to be false`) und vier Fälle des Charakterisierungsnetzes. Die Karte ist
  jetzt das Einzige, was das hält — und sie hält es.

Kein Changelog-Eintrag: für Aufgabenautoren ändert sich nichts.

Refs #1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
