### PR TITLE
Merge der Mehrfachauswahl: Absturz bei Objekt gegen null, und was danach passiert (#1155)

### DIFF
--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.html
@@ -68,3 +68,9 @@
 @if (selectedElements.length === 0) {
   <p class="no-selection">{{'propertiesPanel.noElementSelected' | translate }}</p>
 }
+
+<!--Elements are selected but the merge failed, so there is nothing to render controls from. Without
+    this the pane would simply be blank once the error snackbar times out (#1155).-->
+@if (selectedElements.length > 0 && !combinedProperties) {
+  <p class="no-selection">{{'propertiesPanel.combineFailed' | translate }}</p>
+}

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
@@ -283,6 +283,19 @@ describe('ElementPropertiesPanelComponent', () => {
       expect(combined?.actionParam).toBeNull();
     });
 
+    /* A group against a primitive - a geometry's object-shaped `value` beside a text field's
+       string, say. This never crashed: the recursion ran, found none of the group's keys on the
+       primitive and deleted them all, so the answer was an empty object. `null` is what the merge
+       says everywhere else about two values that disagree (#1155). */
+    it('should null a property group the other element has as a primitive', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'geometry', id: 'a', value: { coordinates: [1, 2] } }),
+        element({ type: 'text-field', id: 'b', value: 'text' })
+      ]);
+
+      expect(combined?.value).toBeNull();
+    });
+
     // The reverse order never crashed, and has to keep answering the same thing.
     it('should null a property group regardless of the selection order', () => {
       const combined = ElementPropertiesPanelComponent.createCombinedProperties([

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
@@ -270,6 +270,28 @@ describe('ElementPropertiesPanelComponent', () => {
 
       expect(combined?.type).toBeNull();
     });
+
+    /* An object on one side and null on the other: the recursion used to be entered on the strength
+       of the first element alone and then walked into `hasOwnProperty.call(null, …)`. A property
+       group that only one of the elements has filled is as diverging as any other pair (#1155). */
+    it('should null a property group the other element has as null', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'trigger', id: 'a', actionParam: { variableId: 'v1', value: '1' } }),
+        element({ type: 'trigger', id: 'b', actionParam: null })
+      ]);
+
+      expect(combined?.actionParam).toBeNull();
+    });
+
+    // The reverse order never crashed, and has to keep answering the same thing.
+    it('should null a property group regardless of the selection order', () => {
+      const combined = ElementPropertiesPanelComponent.createCombinedProperties([
+        element({ type: 'trigger', id: 'b', actionParam: null }),
+        element({ type: 'trigger', id: 'a', actionParam: { variableId: 'v1', value: '1' } })
+      ]);
+
+      expect(combined?.actionParam).toBeNull();
+    });
   });
 
   it('should update the elements property for valid input', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
@@ -76,7 +76,7 @@ describe('ElementPropertiesPanelComponent', () => {
     elementService = createSpyObj<ElementService>(
       ['updateElementsProperty', 'deleteElements', 'duplicateSelectedElements']
     );
-    messageService = createSpyObj<MessageService>(['showWarning']);
+    messageService = createSpyObj<MessageService>(['showWarning', 'showError']);
     selectedElements = new BehaviorSubject<UIElement[]>([]);
     const selectionServiceMock = {
       selectedElements: selectedElements.asObservable(),
@@ -292,6 +292,45 @@ describe('ElementPropertiesPanelComponent', () => {
 
       expect(combined?.actionParam).toBeNull();
     });
+  });
+
+  /* A merge that throws used to leave `selectedElements` on the new selection and
+     `combinedProperties` on the previous one - the panel then showed the old values and wrote them
+     to the newly selected elements. Failing to `undefined` takes the controls away instead (#1155).
+     Provoked through a getter rather than through real elements, because the crash this ticket is
+     about is fixed: what is pinned here is the handling, not that one cause. */
+  it('should show no properties and report when the merge throws', () => {
+    const exploding = { type: 'button', id: 'boom' } as unknown as UIElement;
+    Object.defineProperty(exploding, 'label', {
+      get() { throw new Error('merge failed'); },
+      enumerable: true
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    selectedElements.next([buttonElement]);
+    expect(component.combinedProperties).toBeDefined();
+
+    selectedElements.next([exploding]);
+
+    expect(component.combinedProperties).toBeUndefined();
+    expect(messageService.showError).toHaveBeenCalled();
+  });
+
+  // The write path reads `selectedElements`, so the guarantee is that no control is left to call it.
+  it('should not write the previous selection after a failed merge', () => {
+    const exploding = { type: 'button', id: 'boom' } as unknown as UIElement;
+    Object.defineProperty(exploding, 'label', {
+      get() { throw new Error('merge failed'); },
+      enumerable: true
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    selectedElements.next([buttonElement]);
+    fixture.detectChanges();
+
+    selectedElements.next([exploding]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('aspect-ui-element-properties')).toBeNull();
+    expect(elementService.updateElementsProperty).not.toHaveBeenCalled();
   });
 
   it('should update the elements property for valid input', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
@@ -64,6 +64,7 @@ describe('ElementPropertiesPanelComponent', () => {
   let elementService: SpyObj<ElementService>;
   let messageService: SpyObj<MessageService>;
   let selectedElements: BehaviorSubject<UIElement[]>;
+  let elementPropertyUpdated: Subject<void>;
 
   const buttonElement = {
     type: 'button', id: 'btn1', alias: 'Btn1', label: 'Click'
@@ -83,9 +84,10 @@ describe('ElementPropertiesPanelComponent', () => {
       selectedElementComponents: [],
       isCompoundChildSelected: false
     } as unknown as SelectionService;
+    elementPropertyUpdated = new Subject<void>();
     const unitServiceMock = {
       expertMode: true,
-      elementPropertyUpdated: new Subject<void>()
+      elementPropertyUpdated
     } as unknown as UnitService;
 
     await TestBed.configureTestingModule({
@@ -116,6 +118,12 @@ describe('ElementPropertiesPanelComponent', () => {
     fixture = TestBed.createComponent(ElementPropertiesPanelComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  /* Two tests below stub `console.error`. Without this the stub outlives them and swallows what
+     Angular reports in every test declared after them - vitest does not restore mocks by default. */
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should create', () => {
@@ -344,6 +352,56 @@ describe('ElementPropertiesPanelComponent', () => {
 
     expect(fixture.nativeElement.querySelector('aspect-ui-element-properties')).toBeNull();
     expect(elementService.updateElementsProperty).not.toHaveBeenCalled();
+  });
+
+  /* No controls and no placeholder would leave an empty pane once the snackbar times out - the
+     "no element selected" text does not apply, because elements are selected. */
+  it('should explain the empty pane after a failed merge', () => {
+    const exploding = { type: 'button', id: 'boom' } as unknown as UIElement;
+    Object.defineProperty(exploding, 'label', {
+      get() { throw new Error('merge failed'); },
+      enumerable: true
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    selectedElements.next([exploding]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.no-selection')).not.toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('propertiesPanel.combineFailed');
+  });
+
+  /* `elementPropertyUpdated` fires for edits anywhere in the unit. Re-running the same failing
+     merge on the unchanged broken selection must not put a snackbar on screen for each of them. */
+  it('should report a persistent merge failure only once', () => {
+    const exploding = { type: 'button', id: 'boom' } as unknown as UIElement;
+    Object.defineProperty(exploding, 'label', {
+      get() { throw new Error('merge failed'); },
+      enumerable: true
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    selectedElements.next([exploding]);
+
+    elementPropertyUpdated.next();
+    elementPropertyUpdated.next();
+
+    expect(messageService.showError).toHaveBeenCalledTimes(1);
+  });
+
+  // A selection that merges again clears the mark, so a later failure is reported afresh.
+  it('should report again after the merge has recovered', () => {
+    const exploding = { type: 'button', id: 'boom' } as unknown as UIElement;
+    Object.defineProperty(exploding, 'label', {
+      get() { throw new Error('merge failed'); },
+      enumerable: true
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    selectedElements.next([exploding]);
+    selectedElements.next([buttonElement]);
+    selectedElements.next([exploding]);
+
+    expect(messageService.showError).toHaveBeenCalledTimes(2);
   });
 
   it('should update the elements property for valid input', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
@@ -30,6 +30,8 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
 
   interactionEnabled = false;
   interactionIndeterminate = false;
+  /** Keeps a merge that keeps failing from reporting itself once per unit-wide property update. */
+  private mergeFailureReported = false;
 
   constructor(protected selectionService: SelectionService,
               public unitService: UnitService,
@@ -99,8 +101,12 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
    * `selectedElements` already switched to the new selection while `combinedProperties` still held
    * the previous one - RxJS swallows the error, so the panel went on rendering the old values and
    * `updateModel` wrote them to the newly selected elements on the next edit (#1155). Failing to
-   * `undefined` renders no controls at all, which is the state an empty selection already produces,
-   * so there is nothing left to write with.
+   * `undefined` takes every control away, so there is nothing left to write with; the template
+   * turns that into its own message rather than a blank pane.
+   *
+   * Reported once per failure and not once per call: `elementPropertyUpdated` fires for edits
+   * anywhere in the unit, and re-running the same failing merge on an unchanged broken selection
+   * would put a snackbar on screen for each of them.
    *
    * The bug that made this reachable is fixed; this keeps the next one from corrupting a unit.
    */
@@ -108,8 +114,11 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
     try {
       this.combinedProperties =
         ElementPropertiesPanelComponent.createCombinedProperties(this.selectedElements);
+      this.mergeFailureReported = false;
     } catch (error) {
       this.combinedProperties = undefined;
+      if (this.mergeFailureReported) return;
+      this.mergeFailureReported = true;
       this.messageService.showError(this.translateService.instant('propertiesPanel.combineFailed'));
       // eslint-disable-next-line no-console -- the message above cannot carry the cause
       console.error('Merging the selected elements failed', error);

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
@@ -94,10 +94,25 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * A value the merge can recurse into: a property group, as opposed to a primitive, an array or
+   * `null`. Arrays are excluded because the merge deliberately treats a diverging array as one
+   * value rather than merging it entry by entry - see {@link Merged}.
+   */
+  private static isPropertyGroup(value: unknown): value is UIElement {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  /**
    * Merges the elements property by property: equal values are kept, diverging ones become `null`,
    * and a property that not every element has is dropped. Nested property groups recurse through
    * here too, which is why the two selection-wide keys above are not part of it - a position group
    * has no id and no rows.
+   *
+   * The recursion needs a property group on **both** sides. Testing only the side already in
+   * `merged` walked into `hasOwnProperty.call(null, …)` as soon as the other element had `null`
+   * there - a trigger with an `actionParam` selected before one without, say (#1155). A group
+   * against a non-group is as diverging as any other pair, so it takes the branch below and
+   * becomes `null`.
    */
   private static mergeElements(elements: UIElement[]): CombinedProperties {
     const merged = { ...elements[0] } as CombinedProperties;
@@ -106,9 +121,8 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
       const elementToMerge = elements[elementCounter];
       Object.keys(merged).forEach((property: keyof UIElement) => {
         if (Object.prototype.hasOwnProperty.call(elementToMerge, property)) {
-          if (typeof merged[property] === 'object' &&
-            !Array.isArray(merged[property]) &&
-            merged[property] !== null) {
+          if (ElementPropertiesPanelComponent.isPropertyGroup(merged[property]) &&
+            ElementPropertiesPanelComponent.isPropertyGroup(elementToMerge[property])) {
             merged[property] = ElementPropertiesPanelComponent.mergeElements(
               [(merged[property] as UIElement), (elementToMerge[property] as UIElement)]
             );

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
@@ -44,8 +44,7 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(
         () => {
-          this.combinedProperties =
-            ElementPropertiesPanelComponent.createCombinedProperties(this.selectedElements);
+          this.refreshCombinedProperties();
         }
       );
     this.selectionService.selectedElements
@@ -53,8 +52,7 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
       .subscribe(
         (selectedElements: UIElement[]) => {
           this.selectedElements = selectedElements;
-          this.combinedProperties =
-            ElementPropertiesPanelComponent.createCombinedProperties(this.selectedElements);
+          this.refreshCombinedProperties();
 
           this.interactionEnabled = this.selectionService.selectedElementComponents
             .filter(elementOverlay => elementOverlay instanceof ElementOverlay)
@@ -91,6 +89,31 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
       [...combinedProperties.rows as LikertRowElement[]] :
       undefined;
     return combinedProperties;
+  }
+
+  /**
+   * Rebuilds the merged view of the current selection.
+   *
+   * The merge is the one thing between the selection and everything the panel shows, and it used
+   * to be called straight from both subscribers. An exception in it therefore left
+   * `selectedElements` already switched to the new selection while `combinedProperties` still held
+   * the previous one - RxJS swallows the error, so the panel went on rendering the old values and
+   * `updateModel` wrote them to the newly selected elements on the next edit (#1155). Failing to
+   * `undefined` renders no controls at all, which is the state an empty selection already produces,
+   * so there is nothing left to write with.
+   *
+   * The bug that made this reachable is fixed; this keeps the next one from corrupting a unit.
+   */
+  private refreshCombinedProperties(): void {
+    try {
+      this.combinedProperties =
+        ElementPropertiesPanelComponent.createCombinedProperties(this.selectedElements);
+    } catch (error) {
+      this.combinedProperties = undefined;
+      this.messageService.showError(this.translateService.instant('propertiesPanel.combineFailed'));
+      // eslint-disable-next-line no-console -- the message above cannot carry the cause
+      console.error('Merging the selected elements failed', error);
+    }
   }
 
   /**

--- a/projects/editor/src/assets/i18n/de.json
+++ b/projects/editor/src/assets/i18n/de.json
@@ -91,6 +91,7 @@
     "stacking": "Stapelung",
     "border": "Rahmen",
     "multiSelection": "Mehrfachauswahl",
+    "combineFailed": "Die Eigenschaften der Auswahl konnten nicht zusammengeführt werden. Bitte die Auswahl aufheben und die Elemente einzeln bearbeiten.",
     "inputElement": "Eingabeelement",
     "keyboard": "Tastatur",
     "inputAssistanceGroup": "Eingabehilfe",


### PR DESCRIPTION
Vier Commits. Der erste behebt den gemeldeten Absturz, der zweite den Folgeschaden, den das Ticket
selbst als offene Frage nennt, der dritte hält eine zweite Verhaltensänderung fest, der vierte
arbeitet ein Review ab.

## Der Absturz

`mergeElements` entschied allein anhand des Wertes, der schon im Ergebnis stand, ob rekursiert wird.
Hatte das nächste Element dort `null`, lief die Rekursion mit `[Gruppe, null]` und der innere
Durchlauf traf `Object.prototype.hasOwnProperty.call(null, …)`.

Zwei Auslöser, beim ersten die Aktion „Zustandsvariable ändern" (also `actionParam` als Objekt), beim
zweiten keine — reproduziert, aber **nur in dieser Reihenfolge**. Umgekehrt ist `merged.actionParam`
schon `null`, die erste Bedingung greift nie, und das Paar fällt in den Uneinigkeits-Zweig. Genau das
ließ den Fehler sporadisch wirken.

Jetzt muss auf **beiden** Seiten eine Gruppe stehen. Eine Gruppe gegen eine Nicht-Gruppe ist so
uneinig wie jedes andere Paar und wird `null` — die Antwort, die die umgekehrte Reihenfolge schon
gab.

## Der Folgeschaden wiegt schwerer

`selectedElements` wird **vor** dem Merge zugewiesen. Eine Ausnahme ließ also die neue Auswahl stehen,
während `combinedProperties` die alte behielt. RxJS schluckt das: das Panel zeigte weiter die Werte
des vorigen Elements, und die nächste Bearbeitung schrieb sie — über `updateModel`, das
`selectedElements` liest — auf die **neu** markierten Elemente.

Beide Aufrufstellen gehen jetzt durch eine Methode, die im Fehlerfall auf `undefined` fällt. Damit
gibt es keine Controls und folglich nichts, womit geschrieben werden könnte, dazu eine Meldung im
Panel und die Ursache auf der Konsole.

Die Ursache dafür ist im ersten Commit behoben. Hier geht es um die Klasse: das Panel darf nicht in
einen Zustand geraten können, in dem Angezeigtes und Beschriebenes verschiedene Auswahlen sind.

## Eine zweite Verhaltensänderung, eigener Commit

Beim Selbstreview aufgefallen: die Änderung trifft nicht nur den Absturz. Eine Gruppe gegen ein
**Primitiv** — der objektförmige `value` einer Geometrie neben dem String eines Eingabefelds — ist nie
abgestürzt. Die Rekursion lief, fand keinen der Gruppenschlüssel am Primitiv, löschte alle und lieferte
`{}`. Dem Panel wurde also „sind sich einig, gemeinsamer Wert ist `{}`" gesagt. Jetzt `null`, wie bei
jedem anderen uneinigen Paar. Belegt: gegen den alten Code läuft der neue Test in `expected {} to be null`.

## Was das Review fand

Drei Befunde am Fehlerbehandlungs-Commit, alle vor dem Beheben nachgeprüft:

- **Die Fläche wurde leer.** `undefined` nimmt die Controls weg, aber der „kein Element ausgewählt"-
  Platzhalter hängt an einer leeren Auswahl — und es *sind* Elemente markiert. Nach Ablauf der Snackbar
  blieb also nichts übrig, auch kein Löschen oder Duplizieren. Mein Docstring behauptete, das sei „der
  Zustand, den eine leere Auswahl ohnehin erzeugt" — das war falsch. Eigener Template-Zweig mit eigener
  Meldung.
- **Eine Snackbar pro unit-weiter Änderung.** `elementPropertyUpdated` feuert aus sieben Stellen für
  Änderungen irgendwo in der Aufgabe, und jede ließ denselben Merge erneut scheitern. Jetzt einmal pro
  Fehlerfall, erneut erst nach einem geglückten Merge.
- **Ein `console.error`-Stub überlebte seinen Test** und verschluckte, was Angular in den vier danach
  deklarierten Tests gemeldet hätte. `afterEach` mit `vi.restoreAllMocks()` ergänzt, wie in den anderen
  Specs des Repos.

## Bitte ansehen

Der Fehlerzustand ist im Editor **nicht mehr auslösbar** — die Ursache ist ja weg. Zu sehen gäbe es nur
den neuen Text, falls je wieder etwas im Merge scheitert:

> Die Eigenschaften der Auswahl konnten nicht zusammengeführt werden. Bitte die Auswahl aufheben und die
> Elemente einzeln bearbeiten.

Wenn eine andere Formulierung gewünscht ist, gerne sagen. Nachstellen lässt sich dagegen gut, dass der
gemeldete Absturz weg ist: zwei Auslöser wie oben, in beiden Reihenfolgen markieren, Konsole bleibt still.

## Absicherung

- `ng test editor`: 763 Tests grün (104 Dateien), Charakterisierungsnetz unverändert.
- `ng build editor` sauber, ESLint ohne Errors, `de.json` valide.
- Jeder der vier Commits hat einen ausgeführten Gegencheck, u. a. `Cannot convert undefined or null to
  object` für den Absturz und `called 1 times, but got 3 times` für die Mehrfachmeldung.

Refs #1155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
