### PR TITLE
Eingabeprüfung im Eigenschaftenbereich: das tote isInputValid-Relais und was daran hing (#1154)

### DIFF
--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -37,6 +37,11 @@ Editor
 - Eigenschaftenbereich bei gemeinsamer Markierung
   - Sind mehrere Elemente mit unterschiedlichen Optionslisten markiert, wird die Vorbelegung nicht mehr angeboten (verursachte bislang einen fortlaufenden Fehler in der Browser-Konsole)
   - "Medienquelle ändern" wird bei Elementen unterschiedlichen Typs nicht mehr angeboten; ein Klick darauf löschte zuvor Bild und Dateinamen bei allen markierten Elementen
+  - Behebt einen Fehler, der beim gemeinsamen Markieren von Elementen mit unterschiedlich gefüllten Eigenschaftsgruppen auftrat (z. B. zwei Auslöser, von denen nur einer eine Aktion hat); der Eigenschaftenbereich zeigte danach die Werte der zuvor markierten Elemente an und schrieb sie beim nächsten Bearbeiten auf die neu markierten
+- Zahlenfelder im Eigenschaftenbereich
+  - Ein geleertes Zahlenfeld (z. B. X-Position, z-Index, Schieberegler-Grenzen, Lupengröße, Spaltenanzahl) speichert jetzt 0, statt einen ungültigen Leerwert in die Aufgabendatei zu schreiben; der Wert wird beim Verlassen des Feldes übernommen
+  - Eingaben, die nicht erlaubt sind (z. B. negative Werte), werden nicht mehr gespeichert; das Feld zeigt wieder den gespeicherten Wert und es erscheint der Hinweis "Eingabe ungültig"
+  - Bei gemeinsamer Markierung wirken diese Änderungen auf alle markierten Elemente
 
 ## 2.12.4
 ### Fehlerbehebungen 

--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -39,8 +39,8 @@ Editor
   - "Medienquelle ändern" wird bei Elementen unterschiedlichen Typs nicht mehr angeboten; ein Klick darauf löschte zuvor Bild und Dateinamen bei allen markierten Elementen
   - Behebt einen Fehler, der beim gemeinsamen Markieren von Elementen mit unterschiedlich gefüllten Eigenschaftsgruppen auftrat (z. B. zwei Auslöser, von denen nur einer eine Aktion hat); der Eigenschaftenbereich zeigte danach die Werte der zuvor markierten Elemente an und schrieb sie beim nächsten Bearbeiten auf die neu markierten
 - Zahlenfelder im Eigenschaftenbereich
-  - Ein geleertes Zahlenfeld (z. B. X-Position, z-Index, Schieberegler-Grenzen, Lupengröße, Spaltenanzahl) speichert jetzt 0, statt einen ungültigen Leerwert in die Aufgabendatei zu schreiben; der Wert wird beim Verlassen des Feldes übernommen
-  - Eingaben, die nicht erlaubt sind (z. B. negative Werte), werden nicht mehr gespeichert; das Feld zeigt wieder den gespeicherten Wert und es erscheint der Hinweis "Eingabe ungültig"
+  - Ein geleertes Zahlenfeld (z. B. X-Position, z-Index, Schieberegler-Grenzen, Lupengröße, Spaltenanzahl, Breite und Höhe im Standardmodus) speichert jetzt 0, statt einen ungültigen Leerwert in die Aufgabendatei zu schreiben; der Wert wird beim Verlassen des Feldes übernommen
+  - Eingaben, die nicht erlaubt sind (z. B. negative Werte), werden nicht mehr gespeichert; das Feld zeigt beim Verlassen wieder den gespeicherten Wert und es erscheint einmal der Hinweis "Eingabe ungültig"
   - Bei gemeinsamer Markierung wirken diese Änderungen auf alle markierten Elemente
 
 ## 2.12.4

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
@@ -31,10 +31,9 @@
     <input matInput type="number" #magnifierSize="ngModel" min="0"
            [disabled]="!combinedProperties.magnifier"
            [ngModel]="combinedProperties.magnifierSize"
-           (ngModelChange)="$event !== null && updateModel.emit({
+           (ngModelChange)="$event !== null && magnifierSize.valid && updateModel.emit({
                 property: 'magnifierSize',
-                value: $event,
-                isInputValid: magnifierSize.valid})"
+                value: $event})"
            (change)="commitNumber(magnifierSize, 'magnifierSize', combinedProperties.magnifierSize)">
   </mat-form-field>
 

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
@@ -35,8 +35,7 @@
                 property: 'magnifierSize',
                 value: $event,
                 isInputValid: magnifierSize.valid})"
-           (change)="magnifierSize.value === null &&
-                     updateModel.emit({ property: 'magnifierSize', value: 0, isInputValid: true })">
+           (change)="commitNumber(magnifierSize, 'magnifierSize', combinedProperties.magnifierSize)">
   </mat-form-field>
 
   <div *ngIf="combinedProperties.magnifierZoom !== undefined"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
@@ -33,10 +33,8 @@
            [ngModel]="combinedProperties.magnifierSize"
            (ngModelChange)="updateModel.emit({
                 property: 'magnifierSize',
-                value: $event,
-                isInputValid: magnifierSize.valid})"
-           (change)="combinedProperties.magnifierSize = combinedProperties.magnifierSize ?
-                                                        combinedProperties.magnifierSize : 0">
+                value: $event ?? 0,
+                isInputValid: magnifierSize.valid})">
   </mat-form-field>
 
   <div *ngIf="combinedProperties.magnifierZoom !== undefined"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.html
@@ -31,10 +31,12 @@
     <input matInput type="number" #magnifierSize="ngModel" min="0"
            [disabled]="!combinedProperties.magnifier"
            [ngModel]="combinedProperties.magnifierSize"
-           (ngModelChange)="updateModel.emit({
+           (ngModelChange)="$event !== null && updateModel.emit({
                 property: 'magnifierSize',
-                value: $event ?? 0,
-                isInputValid: magnifierSize.valid})">
+                value: $event,
+                isInputValid: magnifierSize.valid})"
+           (change)="magnifierSize.value === null &&
+                     updateModel.emit({ property: 'magnifierSize', value: 0, isInputValid: true })">
   </mat-form-field>
 
   <div *ngIf="combinedProperties.magnifierZoom !== undefined"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.spec.ts
@@ -96,14 +96,60 @@ describe('ImagePropertiesComponent', () => {
     expect(emitted).toEqual([{ property: 'scale', value: true }]);
   });
 
-  it('should emit the magnifier size together with its validity', () => {
+  it('should emit the magnifier size', () => {
     const sizeInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
     expect(sizeInput.value).toBe('100');
 
     sizeInput.value = '200';
     sizeInput.dispatchEvent(new Event('input'));
 
-    expect(emitted).toEqual([{ property: 'magnifierSize', value: 200, isInputValid: true }]);
+    expect(emitted).toEqual([{ property: 'magnifierSize', value: 200 }]);
+  });
+
+  /* `magnifierSize` is declared `number`, so an emptied box means zero rather than null - and the
+     zero belongs on leaving the field, not on the keystroke that empties it, because a box the
+     browser cannot parse yet reads as empty too (#1154). */
+  describe('leaving the magnifier size field', () => {
+    const sizeInput = (): HTMLInputElement => fixture.nativeElement
+      .querySelector('input[type="number"]') as HTMLInputElement;
+
+    it('should emit zero for a size left empty', () => {
+      sizeInput().value = '';
+      sizeInput().dispatchEvent(new Event('input'));
+      expect(emitted).toEqual([]); // still mid-edit, nothing written
+
+      sizeInput().dispatchEvent(new Event('change'));
+
+      expect(emitted).toEqual([{ property: 'magnifierSize', value: 0, isInputValid: true }]);
+    });
+
+    /* `min="0"` makes -5 invalid. Nothing is written while it is typed, the host is told once on
+       leaving so it can warn, and the box goes back to what the model holds. */
+    it('should report a negative size once and put the box back', async () => {
+      ['-5', '-50'].forEach(value => {
+        sizeInput().value = value;
+        sizeInput().dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+      });
+      expect(emitted).toEqual([]);
+
+      sizeInput().dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(emitted).toEqual([{ property: 'magnifierSize', value: -50, isInputValid: false }]);
+      expect(sizeInput().value).toBe('100');
+    });
+
+    it('should not emit on leaving a field that holds a value', () => {
+      sizeInput().value = '200';
+      sizeInput().dispatchEvent(new Event('input'));
+      emitted.length = 0;
+
+      sizeInput().dispatchEvent(new Event('change'));
+
+      expect(emitted).toEqual([]);
+    });
   });
 
   it('should disable the magnifier size when the magnifier is off', async () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.ts
@@ -26,10 +26,13 @@ export class ImagePropertiesComponent {
    * refused by the guard in the host, so the box has to go back to what the model holds.
    *
    * Nothing is emitted while typing, because a box the browser cannot parse yet reads as empty too
-   * and writing then stamps the value back over what is being typed.
+   * and writing then stamps the value back over what is being typed. The invalid value is reported
+   * from here for the same reason: warning per keystroke put one warning after the other on screen
+   * for a single edit. One edit, one warning.
    */
   commitNumber(control: NgModel, property: keyof ImageProperties, modelValue: number | null | undefined): void {
     if (control.invalid) {
+      this.updateModel.emit({ property, value: control.value, isInputValid: false });
       /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
          typing and emit the rejected value straight out again. */
       control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/image-properties/image-properties.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
+import { NgModel } from '@angular/forms';
 import { ImageProperties } from 'common/models/elements/interactive-group-elements/image';
 import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-properties';
 
@@ -18,4 +19,22 @@ export class ImagePropertiesComponent {
       value: string | number | boolean | null,
       isInputValid?: boolean | null
     }>();
+
+  /**
+   * A number field has been left. The emit on `ngModelChange` handles neither case: an empty box
+   * means zero, because these properties are declared `number` (#1154), and an invalid value was
+   * refused by the guard in the host, so the box has to go back to what the model holds.
+   *
+   * Nothing is emitted while typing, because a box the browser cannot parse yet reads as empty too
+   * and writing then stamps the value back over what is being typed.
+   */
+  commitNumber(control: NgModel, property: keyof ImageProperties, modelValue: number | null | undefined): void {
+    if (control.invalid) {
+      /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
+         typing and emit the rejected value straight out again. */
+      control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
+      return;
+    }
+    if (control.value === null) this.updateModel.emit({ property, value: 0, isInputValid: true });
+  }
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
@@ -4,10 +4,8 @@
          [ngModel]="combinedProperties.minValue"
          (ngModelChange)="updateModel.emit({
                 property: 'minValue',
-                value: $event,
-                isInputValid: minValue.valid})"
-         (change)="combinedProperties.minValue = combinedProperties.minValue ?
-                                                        combinedProperties.minValue : 0">
+                value: $event ?? 0,
+                isInputValid: minValue.valid})">
 </mat-form-field>
 <mat-form-field *ngIf="combinedProperties.maxValue !== undefined" appearance="fill">
   <mat-label>{{'propertiesPanel.maxValue' | translate }}</mat-label>
@@ -15,10 +13,8 @@
          [ngModel]="combinedProperties.maxValue"
          (ngModelChange)="updateModel.emit({
                 property: 'maxValue',
-                value: $event,
-                isInputValid: maxValue.valid})"
-         (change)="combinedProperties.maxValue = combinedProperties.maxValue ?
-                                                        combinedProperties.maxValue : 0">
+                value: $event ?? 0,
+                isInputValid: maxValue.valid})">
 </mat-form-field>
 <aspect-merged-checkbox *ngIf="unitService.expertMode && combinedProperties.showValues !== undefined"
                         [value]="combinedProperties.showValues"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
@@ -2,19 +2,23 @@
   <mat-label>{{'propertiesPanel.minValue' | translate }}</mat-label>
   <input matInput type="number" #minValue="ngModel"
          [ngModel]="combinedProperties.minValue"
-         (ngModelChange)="updateModel.emit({
+         (ngModelChange)="$event !== null && updateModel.emit({
                 property: 'minValue',
-                value: $event ?? 0,
-                isInputValid: minValue.valid})">
+                value: $event,
+                isInputValid: minValue.valid})"
+         (change)="minValue.value === null &&
+                   updateModel.emit({ property: 'minValue', value: 0, isInputValid: true })">
 </mat-form-field>
 <mat-form-field *ngIf="combinedProperties.maxValue !== undefined" appearance="fill">
   <mat-label>{{'propertiesPanel.maxValue' | translate }}</mat-label>
   <input matInput type="number" #maxValue="ngModel"
          [ngModel]="combinedProperties.maxValue"
-         (ngModelChange)="updateModel.emit({
+         (ngModelChange)="$event !== null && updateModel.emit({
                 property: 'maxValue',
-                value: $event ?? 0,
-                isInputValid: maxValue.valid})">
+                value: $event,
+                isInputValid: maxValue.valid})"
+         (change)="maxValue.value === null &&
+                   updateModel.emit({ property: 'maxValue', value: 0, isInputValid: true })">
 </mat-form-field>
 <aspect-merged-checkbox *ngIf="unitService.expertMode && combinedProperties.showValues !== undefined"
                         [value]="combinedProperties.showValues"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
@@ -2,20 +2,18 @@
   <mat-label>{{'propertiesPanel.minValue' | translate }}</mat-label>
   <input matInput type="number" #minValue="ngModel"
          [ngModel]="combinedProperties.minValue"
-         (ngModelChange)="$event !== null && updateModel.emit({
+         (ngModelChange)="$event !== null && minValue.valid && updateModel.emit({
                 property: 'minValue',
-                value: $event,
-                isInputValid: minValue.valid})"
+                value: $event})"
          (change)="commitNumber(minValue, 'minValue', combinedProperties.minValue)">
 </mat-form-field>
 <mat-form-field *ngIf="combinedProperties.maxValue !== undefined" appearance="fill">
   <mat-label>{{'propertiesPanel.maxValue' | translate }}</mat-label>
   <input matInput type="number" #maxValue="ngModel"
          [ngModel]="combinedProperties.maxValue"
-         (ngModelChange)="$event !== null && updateModel.emit({
+         (ngModelChange)="$event !== null && maxValue.valid && updateModel.emit({
                 property: 'maxValue',
-                value: $event,
-                isInputValid: maxValue.valid})"
+                value: $event})"
          (change)="commitNumber(maxValue, 'maxValue', combinedProperties.maxValue)">
 </mat-form-field>
 <aspect-merged-checkbox *ngIf="unitService.expertMode && combinedProperties.showValues !== undefined"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.html
@@ -6,8 +6,7 @@
                 property: 'minValue',
                 value: $event,
                 isInputValid: minValue.valid})"
-         (change)="minValue.value === null &&
-                   updateModel.emit({ property: 'minValue', value: 0, isInputValid: true })">
+         (change)="commitNumber(minValue, 'minValue', combinedProperties.minValue)">
 </mat-form-field>
 <mat-form-field *ngIf="combinedProperties.maxValue !== undefined" appearance="fill">
   <mat-label>{{'propertiesPanel.maxValue' | translate }}</mat-label>
@@ -17,8 +16,7 @@
                 property: 'maxValue',
                 value: $event,
                 isInputValid: maxValue.valid})"
-         (change)="maxValue.value === null &&
-                   updateModel.emit({ property: 'maxValue', value: 0, isInputValid: true })">
+         (change)="commitNumber(maxValue, 'maxValue', combinedProperties.maxValue)">
 </mat-form-field>
 <aspect-merged-checkbox *ngIf="unitService.expertMode && combinedProperties.showValues !== undefined"
                         [value]="combinedProperties.showValues"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.spec.ts
@@ -88,7 +88,7 @@ describe('SliderPropertiesComponent', () => {
     maxValueInput.value = '50';
     maxValueInput.dispatchEvent(new Event('input'));
 
-    expect(emitted).toEqual([{ property: 'maxValue', value: 50, isInputValid: true }]);
+    expect(emitted).toEqual([{ property: 'maxValue', value: 50 }]);
   });
 
   /* `minValue`/`maxValue` are declared `number`. An empty number field is *valid* to Angular, so

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.spec.ts
@@ -97,14 +97,29 @@ describe('SliderPropertiesComponent', () => {
 
      The preset below is deliberately not treated this way: its property is `InputElementValue`,
      where null is a legitimate "no preset". */
-  it('should emit zero rather than null for an emptied maximum value', () => {
+  it('should emit zero for a maximum value left empty, on leaving the field', () => {
     const maxValueInput = Array.from(
       fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
     )[1];
+
     maxValueInput.value = '';
     maxValueInput.dispatchEvent(new Event('input'));
+    expect(emitted).toEqual([]); // still mid-edit, nothing written
+
+    maxValueInput.dispatchEvent(new Event('change'));
 
     expect(emitted).toEqual([{ property: 'maxValue', value: 0, isInputValid: true }]);
+  });
+
+  /* The bounds carry no `min`, and negative ones are supported. Emitting on the keystroke that
+     leaves the box unparsable would write 0 and stamp it over the "-" being typed. */
+  it('should let a negative minimum be typed', () => {
+    const minValueInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+
+    minValueInput.value = '';
+    minValueInput.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual([]);
   });
 
   it('should emit updateModel when a checkbox is toggled', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.spec.ts
@@ -91,6 +91,22 @@ describe('SliderPropertiesComponent', () => {
     expect(emitted).toEqual([{ property: 'maxValue', value: 50, isInputValid: true }]);
   });
 
+  /* `minValue`/`maxValue` are declared `number`. An empty number field is *valid* to Angular, so
+     before #1154 nothing stopped null from being written here - unlike the position fields, this
+     leaf never even checked for it. Empty means 0 now, and the value is written as such.
+
+     The preset below is deliberately not treated this way: its property is `InputElementValue`,
+     where null is a legitimate "no preset". */
+  it('should emit zero rather than null for an emptied maximum value', () => {
+    const maxValueInput = Array.from(
+      fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
+    )[1];
+    maxValueInput.value = '';
+    maxValueInput.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual([{ property: 'maxValue', value: 0, isInputValid: true }]);
+  });
+
   it('should emit updateModel when a checkbox is toggled', () => {
     const barStyleInput = Array.from(
       fixture.nativeElement.querySelectorAll('mat-checkbox input') as NodeListOf<HTMLInputElement>

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
+import { NgModel } from '@angular/forms';
 import { SliderProperties } from 'common/models/elements/input-group-elements/slider';
 import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-properties';
 import { UnitService } from 'editor/src/app/services/unit.service';
@@ -21,4 +22,22 @@ export class SliderPropertiesComponent {
     }>();
 
   constructor(public unitService: UnitService) { }
+
+  /**
+   * A number field has been left. The emit on `ngModelChange` handles neither case: an empty box
+   * means zero, because these properties are declared `number` (#1154), and an invalid value was
+   * refused by the guard in the host, so the box has to go back to what the model holds.
+   *
+   * Nothing is emitted while typing, because a box the browser cannot parse yet reads as empty too
+   * and writing then stamps the value back over what is being typed.
+   */
+  commitNumber(control: NgModel, property: keyof SliderProperties, modelValue: number | null | undefined): void {
+    if (control.invalid) {
+      /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
+         typing and emit the rejected value straight out again. */
+      control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
+      return;
+    }
+    if (control.value === null) this.updateModel.emit({ property, value: 0, isInputValid: true });
+  }
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/slider-properties/slider-properties.component.ts
@@ -29,10 +29,13 @@ export class SliderPropertiesComponent {
    * refused by the guard in the host, so the box has to go back to what the model holds.
    *
    * Nothing is emitted while typing, because a box the browser cannot parse yet reads as empty too
-   * and writing then stamps the value back over what is being typed.
+   * and writing then stamps the value back over what is being typed. The invalid value is reported
+   * from here for the same reason: warning per keystroke put one warning after the other on screen
+   * for a single edit. One edit, one warning.
    */
   commitNumber(control: NgModel, property: keyof SliderProperties, modelValue: number | null | undefined): void {
     if (control.invalid) {
+      this.updateModel.emit({ property, value: control.value, isInputValid: false });
       /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
          typing and emit the rejected value straight out again. */
       control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.html
@@ -3,17 +3,19 @@
 @if (show.geometrySize) {
   <mat-form-field appearance="fill">
     <mat-label>{{'propertiesPanel.width' | translate }}</mat-label>
-    <input matInput type="number" min="0"
+    <input matInput type="number" min="0" #geometryWidth="ngModel"
            [ngModel]="combinedProperties.dimensions?.width"
-           (ngModelChange)="updateDimensionProperty('width', $event)">
+           (ngModelChange)="$event !== null && geometryWidth.valid && updateDimensionProperty('width', $event)"
+           (change)="commitNumber(geometryWidth, 'width', combinedProperties.dimensions?.width)">
   </mat-form-field>
   <mat-form-field>
     <mat-label>
       {{'propertiesPanel.height' | translate }}
     </mat-label>
-    <input matInput type="number" min="0"
+    <input matInput type="number" min="0" #geometryHeight="ngModel"
            [ngModel]="combinedProperties.dimensions?.height"
-           (ngModelChange)="updateDimensionProperty('height', $event)">
+           (ngModelChange)="$event !== null && geometryHeight.valid && updateDimensionProperty('height', $event)"
+           (change)="commitNumber(geometryHeight, 'height', combinedProperties.dimensions?.height)">
   </mat-form-field>
 }
 
@@ -28,8 +30,8 @@
       <input matInput type="number" min="0" #widthField="ngModel"
              [disabled]="!fixedWidth.checked"
              [ngModel]="combinedProperties.dimensions.width"
-             (ngModelChange)="$event !== null && updateDimensionProperty('width', $event)"
-             (change)="widthField.value === null && updateDimensionProperty('width', 0)">
+             (ngModelChange)="$event !== null && widthField.valid && updateDimensionProperty('width', $event)"
+             (change)="commitNumber(widthField, 'width', combinedProperties.dimensions.width)">
     </mat-form-field>
   }
 
@@ -44,10 +46,11 @@
       <mat-label>
         {{'propertiesPanel.maxWidth' | translate }}
       </mat-label>
-      <input matInput type="number" min="0"
+      <input matInput type="number" min="0" #maxWidthField="ngModel"
              [disabled]="!maxWidthEnabled.checked"
              [ngModel]="combinedProperties.dimensions.maxWidth"
-             (ngModelChange)="updateDimensionProperty('maxWidth', $event)">
+             (ngModelChange)="maxWidthField.valid && updateDimensionProperty('maxWidth', $event)"
+             (change)="revertIfInvalid(maxWidthField, combinedProperties.dimensions.maxWidth)">
     </mat-form-field>
   }
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.html
@@ -25,12 +25,11 @@
     </aspect-merged-checkbox>
     <mat-form-field appearance="fill">
       <mat-label>{{'propertiesPanel.width' | translate }}</mat-label>
-      <input matInput type="number" min="0"
+      <input matInput type="number" min="0" #widthField="ngModel"
              [disabled]="!fixedWidth.checked"
              [ngModel]="combinedProperties.dimensions.width"
-             (ngModelChange)="updateDimensionProperty('width', $event)"
-             (change)="combinedProperties.dimensions.width =
-               combinedProperties.dimensions.width ? combinedProperties.dimensions.width : 0">
+             (ngModelChange)="$event !== null && updateDimensionProperty('width', $event)"
+             (change)="widthField.value === null && updateDimensionProperty('width', 0)">
     </mat-form-field>
   }
 

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.spec.ts
@@ -10,6 +10,7 @@ import { UIElement } from 'common/models/elements/element';
 import { UIElementType } from 'common/models/ui-element-interfaces';
 import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
 import { ElementService } from 'editor/src/app/services/element.service';
+import { MessageService } from 'editor/src/app/services/message.service';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import {
   MergedCheckboxComponent
@@ -23,6 +24,7 @@ describe('StandardDimensionPropertiesComponent', () => {
   let component: StandardDimensionPropertiesComponent;
   let fixture: ComponentFixture<StandardDimensionPropertiesComponent>;
   let elementService: SpyObj<ElementService>;
+  let messageService: SpyObj<MessageService>;
 
   const selectedElement = { type: 'drop-list', id: 'dl1' } as unknown as UIElement;
 
@@ -40,6 +42,7 @@ describe('StandardDimensionPropertiesComponent', () => {
 
   beforeEach(async () => {
     elementService = createSpyObj<ElementService>(['updateElementsDimensionsProperty']);
+    messageService = createSpyObj<MessageService>(['showWarning']);
 
     await TestBed.configureTestingModule({
       declarations: [StandardDimensionPropertiesComponent, MergedCheckboxComponent],
@@ -54,6 +57,7 @@ describe('StandardDimensionPropertiesComponent', () => {
       ],
       providers: [
         { provide: ElementService, useValue: elementService },
+        { provide: MessageService, useValue: messageService },
         { provide: SelectionService, useValue: { getSelectedElements: () => [selectedElement] } }
       ]
     }).compileComponents();
@@ -115,6 +119,95 @@ describe('StandardDimensionPropertiesComponent', () => {
     component.toggleProperty('maxWidth', true);
 
     expect(elementService.updateElementsDimensionsProperty).not.toHaveBeenCalled();
+  });
+
+  /* These fields write into the ElementService straight from this component instead of emitting up
+     to the host, so the host's guard never saw them: `min="0"` was on all four boxes and meant
+     nothing, and an emptied box sent null into a property declared `number` (#1154). */
+  describe('the guard on the size fields', () => {
+    beforeEach(async () => {
+      select('geometry');
+      component.combinedProperties = {
+        dimensions: { width: 240, height: 100, maxWidth: 400 }
+      };
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('should write zero for a width left empty, on leaving the field', () => {
+      const widthField = numberFields()[0];
+
+      widthField.value = '';
+      widthField.dispatchEvent(new Event('input'));
+      expect(elementService.updateElementsDimensionsProperty).not.toHaveBeenCalled(); // mid-edit
+
+      widthField.dispatchEvent(new Event('change'));
+
+      expect(elementService.updateElementsDimensionsProperty)
+        .toHaveBeenCalledWith([selectedElement], 'width', 0);
+    });
+
+    it('should refuse a negative height and put the box back', async () => {
+      const heightField = numberFields()[1];
+
+      heightField.value = '-5';
+      heightField.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      expect(elementService.updateElementsDimensionsProperty).not.toHaveBeenCalled();
+
+      heightField.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(elementService.updateElementsDimensionsProperty).not.toHaveBeenCalled();
+      expect(heightField.value).toBe('100');
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
+
+    /* One warning for the whole edit: typing `-50` passes through `-5`, and warning on the
+       keystroke put one warning on screen after the other for a single edit. */
+    it('should warn once for an edit that passes through several invalid values', async () => {
+      const heightField = numberFields()[1];
+
+      ['-5', '-50'].forEach(value => {
+        heightField.value = value;
+        heightField.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+      });
+      heightField.dispatchEvent(new Event('change'));
+      await fixture.whenStable();
+
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
+
+    /* `maxWidth` is `number | null`, so unlike width and height an empty box is the legitimate
+       "no maximum" and must not be turned into a 0. */
+    it('should leave an emptied maximum width empty', () => {
+      const maxWidthField = numberFields()[2];
+
+      maxWidthField.value = '';
+      maxWidthField.dispatchEvent(new Event('input'));
+      maxWidthField.dispatchEvent(new Event('change'));
+
+      expect(elementService.updateElementsDimensionsProperty)
+        .toHaveBeenCalledWith([selectedElement], 'maxWidth', null);
+      expect(messageService.showWarning).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a negative maximum width', async () => {
+      const maxWidthField = numberFields()[2];
+
+      maxWidthField.value = '-1';
+      maxWidthField.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      maxWidthField.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(elementService.updateElementsDimensionsProperty).not.toHaveBeenCalled();
+      expect(maxWidthField.value).toBe('400');
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
   });
 
   /* The block used to be a direct child of the panel's flex column; as a component it needs to be

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/standard-dimension-properties/standard-dimension-properties.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input } from '@angular/core';
+import { NgModel } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
 import { DimensionProperties } from 'common/models/elements/property-group-interfaces';
 import { UIElementProperties } from 'common/models/ui-element-interfaces';
 import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-properties';
@@ -6,6 +8,7 @@ import {
   PanelSection, panelSectionsOf
 } from 'editor/src/app/modules/properties-panel/models/panel-sections';
 import { ElementService } from 'editor/src/app/services/element.service';
+import { MessageService } from 'editor/src/app/services/message.service';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 
 /**
@@ -33,7 +36,9 @@ export class StandardDimensionPropertiesComponent {
   @Input() show: Record<PanelSection, boolean> = panelSectionsOf([]);
 
   constructor(private elementService: ElementService,
-              private selectionService: SelectionService) { }
+              private selectionService: SelectionService,
+              private messageService: MessageService,
+              private translateService: TranslateService) { }
 
   /** Unchecking the box clears the property rather than leaving the last number behind. */
   toggleProperty(property: keyof DimensionProperties, checked: boolean): void {
@@ -44,5 +49,41 @@ export class StandardDimensionPropertiesComponent {
 
   updateDimensionProperty(property: keyof DimensionProperties, value: number | boolean | null): void {
     this.elementService.updateElementsDimensionsProperty(this.selectionService.getSelectedElements(), property, value);
+  }
+
+  /**
+   * A size field has been left. `width` and `height` are declared `number`, so an empty box means
+   * zero (#1154). Nothing is written while typing, because a box the browser cannot parse yet - a
+   * lone `-`, say - reads as empty too, and writing then stamps the value back over what is being
+   * typed.
+   */
+  commitNumber(control: NgModel,
+               property: keyof DimensionProperties,
+               modelValue: number | null | undefined): void {
+    if (control.invalid) {
+      this.refuse(control, modelValue);
+      return;
+    }
+    if (control.value === null) this.updateDimensionProperty(property, 0);
+  }
+
+  /** `maxWidth` is `number | null`: an empty box means "no maximum" and is left alone. */
+  revertIfInvalid(control: NgModel, modelValue: number | null | undefined): void {
+    if (control.invalid) this.refuse(control, modelValue);
+  }
+
+  /**
+   * Unlike every other tab, these fields write into the `ElementService` from this component rather
+   * than emitting up to the host, so the guard the host applies has to be repeated here - without
+   * it the `min="0"` on all four boxes meant nothing and a negative size was saved (#1154).
+   *
+   * Warning on leaving rather than per keystroke: typing `-50` passes through `-5`, and a warning
+   * each would put one after the other on screen for a single edit.
+   */
+  private refuse(control: NgModel, modelValue: number | null | undefined): void {
+    this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+    /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
+       typing and write the rejected value after all. */
+    control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
   }
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.html
@@ -40,7 +40,8 @@
            (ngModelChange)="updateModel.emit({
                 property: 'minLength',
                 value: $event,
-                isInputValid: minLength.valid })">
+                isInputValid: minLength.valid })"
+           (change)="revertIfInvalid(minLength, combinedProperties.minLength)">
   </mat-form-field>
   <mat-form-field class="wide-form-field" appearance="fill">
     <mat-label>{{'propertiesPanel.minLengthWarnMessage' | translate }}</mat-label>
@@ -59,7 +60,8 @@
            (ngModelChange)="updateModel.emit({
                 property: 'maxLength',
                 value: $event,
-                isInputValid: maxLength.valid })">
+                isInputValid: maxLength.valid })"
+           (change)="revertIfInvalid(maxLength, combinedProperties.maxLength)">
   </mat-form-field>
   <aspect-merged-checkbox *ngIf="combinedProperties.isLimitedToMaxLength !== undefined"
                           [disabled]="!combinedProperties.maxLength"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.html
@@ -37,11 +37,10 @@
     <mat-label>{{'propertiesPanel.minLength' | translate }}</mat-label>
     <input matInput type="number" #minLength="ngModel" min="0"
            [ngModel]="combinedProperties.minLength"
-           (ngModelChange)="updateModel.emit({
+           (ngModelChange)="minLength.valid && updateModel.emit({
                 property: 'minLength',
-                value: $event,
-                isInputValid: minLength.valid })"
-           (change)="revertIfInvalid(minLength, combinedProperties.minLength)">
+                value: $event })"
+           (change)="revertIfInvalid(minLength, 'minLength', combinedProperties.minLength)">
   </mat-form-field>
   <mat-form-field class="wide-form-field" appearance="fill">
     <mat-label>{{'propertiesPanel.minLengthWarnMessage' | translate }}</mat-label>
@@ -57,11 +56,10 @@
     <mat-label>{{'propertiesPanel.maxLength' | translate }}</mat-label>
     <input matInput type="number" #maxLength="ngModel" min="0"
            [ngModel]="combinedProperties.maxLength"
-           (ngModelChange)="updateModel.emit({
+           (ngModelChange)="maxLength.valid && updateModel.emit({
                 property: 'maxLength',
-                value: $event,
-                isInputValid: maxLength.valid })"
-           (change)="revertIfInvalid(maxLength, combinedProperties.maxLength)">
+                value: $event })"
+           (change)="revertIfInvalid(maxLength, 'maxLength', combinedProperties.maxLength)">
   </mat-form-field>
   <aspect-merged-checkbox *ngIf="combinedProperties.isLimitedToMaxLength !== undefined"
                           [disabled]="!combinedProperties.maxLength"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.spec.ts
@@ -110,6 +110,43 @@ describe('TextFieldElementPropertiesComponent', () => {
     expect(emitted).toEqual([{ property: 'textAlign', value: 'center' }]);
   });
 
+  /* `min="0"` makes -1 invalid, so the guard in the host refuses it. Nothing then puts the box
+     back on its own, and it would keep showing a number the model never took (#1154). */
+  it('should put a rejected maximum length back to the model value', async () => {
+    const maxLengthInput = Array.from(
+      fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
+    )[1];
+    maxLengthInput.value = '-1';
+    maxLengthInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    emitted.length = 0;
+
+    maxLengthInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(maxLengthInput.value).toBe('10');
+    expect(emitted).toEqual([]); // putting the box back is not a write
+  });
+
+  /* Unlike the `number` properties elsewhere, these are `number | null` - an empty box means
+     "no limit" and must stay empty rather than being turned into a 0. */
+  it('should leave an emptied maximum length empty', async () => {
+    const maxLengthInput = Array.from(
+      fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
+    )[1];
+    maxLengthInput.value = '';
+    maxLengthInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    maxLengthInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(maxLengthInput.value).toBe('');
+    expect(emitted).toEqual([{ property: 'maxLength', value: null, isInputValid: true }]);
+  });
+
   it('should hide the expert mode fields in simple mode', () => {
     unitServiceMock.expertMode = false;
     fixture.detectChanges();

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.spec.ts
@@ -110,23 +110,29 @@ describe('TextFieldElementPropertiesComponent', () => {
     expect(emitted).toEqual([{ property: 'textAlign', value: 'center' }]);
   });
 
-  /* `min="0"` makes -1 invalid, so the guard in the host refuses it. Nothing then puts the box
-     back on its own, and it would keep showing a number the model never took (#1154). */
-  it('should put a rejected maximum length back to the model value', async () => {
+  /* `min="0"` makes -1 invalid. Nothing is written while it is typed, and nothing would put the box
+     back on its own either - it would keep showing a number the model never took (#1154).
+
+     The single emit is what makes the host warn. It carries `isInputValid: false`, so it is a
+     report rather than a write, and it comes on leaving the field: typing `-12` passes through
+     `-1`, and warning per keystroke put one warning on screen after the other. */
+  it('should report a rejected maximum length once and put the box back', async () => {
     const maxLengthInput = Array.from(
       fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
     )[1];
-    maxLengthInput.value = '-1';
-    maxLengthInput.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    emitted.length = 0;
+    ['-1', '-12'].forEach(value => {
+      maxLengthInput.value = value;
+      maxLengthInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+    });
+    expect(emitted).toEqual([]);
 
     maxLengthInput.dispatchEvent(new Event('change'));
     fixture.detectChanges();
     await fixture.whenStable();
 
     expect(maxLengthInput.value).toBe('10');
-    expect(emitted).toEqual([]); // putting the box back is not a write
+    expect(emitted).toEqual([{ property: 'maxLength', value: -12, isInputValid: false }]);
   });
 
   /* Unlike the `number` properties elsewhere, these are `number | null` - an empty box means
@@ -144,7 +150,7 @@ describe('TextFieldElementPropertiesComponent', () => {
     await fixture.whenStable();
 
     expect(maxLengthInput.value).toBe('');
-    expect(emitted).toEqual([{ property: 'maxLength', value: null, isInputValid: true }]);
+    expect(emitted).toEqual([{ property: 'maxLength', value: null }]);
   });
 
   it('should hide the expert mode fields in simple mode', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.ts
@@ -1,7 +1,7 @@
 import {
   Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges
 } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, NgModel } from '@angular/forms';
 import { UnitService } from 'editor/src/app/services/unit.service';
 import { TextFieldProperties } from 'common/models/elements/text-input-group-elements/text-field';
 import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-properties';
@@ -43,5 +43,19 @@ export class TextFieldElementPropertiesComponent implements OnInit, OnChanges {
     } catch (e) {
       this.regexPatternFormControl.setErrors({ invalidPattern: true });
     }
+  }
+
+  /**
+   * A length limit field has been left.
+   *
+   * Unlike the `number` properties elsewhere in the panel these are `number | null`, where an empty
+   * box legitimately means "no limit" - so there is nothing to substitute. What is needed is the
+   * other half: `min="0"` makes -1 invalid, the guard in the host refuses it, and the box must not
+   * go on showing a value the model never took (#1154).
+   */
+  // eslint-disable-next-line class-methods-use-this
+  revertIfInvalid(control: NgModel, modelValue: number | null | undefined): void {
+    // `emitViewToModelChange: false`, or putting the box back would emit the refused value again.
+    if (control.invalid) control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
   }
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-field-element-properties/text-field-element-properties.component.ts
@@ -50,12 +50,17 @@ export class TextFieldElementPropertiesComponent implements OnInit, OnChanges {
    *
    * Unlike the `number` properties elsewhere in the panel these are `number | null`, where an empty
    * box legitimately means "no limit" - so there is nothing to substitute. What is needed is the
-   * other half: `min="0"` makes -1 invalid, the guard in the host refuses it, and the box must not
-   * go on showing a value the model never took (#1154).
+   * other half: `min="0"` makes -1 invalid, nothing is written while it is being typed, and the box
+   * must not go on showing a value the model never took (#1154).
+   *
+   * The warning is raised from here rather than on every keystroke, because typing `-50` passes
+   * through `-5` and put one warning on screen after the other for a single edit.
    */
-  // eslint-disable-next-line class-methods-use-this
-  revertIfInvalid(control: NgModel, modelValue: number | null | undefined): void {
+  revertIfInvalid(control: NgModel, property: keyof TextFieldProperties,
+                  modelValue: number | null | undefined): void {
+    if (!control.invalid) return;
+    this.updateModel.emit({ property, value: control.value, isInputValid: false });
     // `emitViewToModelChange: false`, or putting the box back would emit the refused value again.
-    if (control.invalid) control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
+    control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
   }
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.html
@@ -12,9 +12,8 @@
                   appearance="fill">
     <mat-label>{{ 'propertiesPanel.columnCount' | translate }}</mat-label>
     <input #columnCountField matInput type="number" [value]="combinedProperties.columnCount"
-           (input)="emitOwn('columnCount', columnCountField.value)"
-           (change)="combinedProperties.columnCount = combinedProperties.columnCount ?
-                                                        combinedProperties.columnCount : 0">
+           (input)="columnCountField.value !== '' && emitOwn('columnCount', +columnCountField.value)"
+           (change)="columnCountField.value === '' && emitOwn('columnCount', 0)">
   </mat-form-field>
 
   <fieldset class="fx-column-start-stretch">

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.spec.ts
@@ -141,11 +141,29 @@ describe('TextPropsComponent', () => {
     expect(emitted[0].value).not.toBe(markingPanels);
   });
 
-  it('should emit the edited column count', () => {
+  /* A number, not the raw string of `input.value`. `columnCount` is declared `number`, and the
+     string is one of the six entries #1148 lists - fixed here because this field had to be touched
+     anyway: its `(change)` handler used to write into the merged view object (#1154). */
+  it('should emit the edited column count as a number', () => {
     const columnCountInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
     columnCountInput.value = '3';
     columnCountInput.dispatchEvent(new Event('input'));
 
-    expect(emitted).toEqual([{ property: 'columnCount', value: '3' }]);
+    expect(emitted).toEqual([{ property: 'columnCount', value: 3 }]);
+  });
+
+  /* Empty means zero, committed on leaving the field. Emitting while typing would write over the
+     box; the old `(change)` handler patched only the merged object, so the panel showed 0 while
+     the saved unit definition kept what the emit had put there. */
+  it('should emit zero for a column count left empty', () => {
+    const columnCountInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+
+    columnCountInput.value = '';
+    columnCountInput.dispatchEvent(new Event('input'));
+    expect(emitted).toEqual([]);
+
+    columnCountInput.dispatchEvent(new Event('change'));
+
+    expect(emitted).toEqual([{ property: 'columnCount', value: 0 }]);
   });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-position-properties/element-position-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-position-properties/element-position-properties.component.html
@@ -3,7 +3,7 @@
     *ngIf="positionProperties"
     [positionProperties]="positionProperties"
     [isZIndexDisabled]="isZIndexDisabled"
-    (updateModel)="elementService.updateSelectedElementsPositionProperty($event.property, $event.value)">
+    (updateModel)="updatePositionModel.emit($event)">
   </aspect-position-field-set>
 
   <aspect-dimension-field-set *ngIf="dimensions"

--- a/projects/editor/src/app/modules/properties-panel/components/element-position-properties/element-position-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-position-properties/element-position-properties.component.spec.ts
@@ -103,13 +103,19 @@ describe('ElementPositionPropertiesComponent', () => {
     expect(elementService.alignElements).toHaveBeenCalledWith(selectedElements.value, 'left');
   });
 
-  it('should forward position updates to the element service', () => {
+  /* Up to the host rather than into the service: the host is the one place that evaluates
+     `isInputValid`, and writing from here meant the field set's own guard never took effect
+     (#1154). The flag has to survive the hop, so it is asserted along with the rest. */
+  it('should send position updates up rather than to the element service', () => {
+    const emitted: unknown[] = [];
+    component.updatePositionModel.subscribe(update => emitted.push(update));
     const positionFieldSet = fixture.debugElement
       .query(debugElement => debugElement.componentInstance instanceof MockPositionFieldSetComponent)
       .componentInstance as MockPositionFieldSetComponent;
 
-    positionFieldSet.updateModel.emit({ property: 'xPosition', value: 10 });
+    positionFieldSet.updateModel.emit({ property: 'xPosition', value: 10, isInputValid: false });
 
-    expect(elementService.updateSelectedElementsPositionProperty).toHaveBeenCalledWith('xPosition', 10);
+    expect(emitted).toEqual([{ property: 'xPosition', value: 10, isInputValid: false }]);
+    expect(elementService.updateSelectedElementsPositionProperty).not.toHaveBeenCalled();
   });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-position-properties/element-position-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-position-properties/element-position-properties.component.ts
@@ -1,9 +1,9 @@
 import {
-  Component, Input
+  Component, EventEmitter, Input, Output
 } from '@angular/core';
 import { DimensionProperties, PositionProperties } from 'common/models/elements/property-group-interfaces';
 import { ElementService } from 'editor/src/app/services/element.service';
-import { PositionedUIElement } from 'common/models/ui-element-interfaces';
+import { PositionedUIElement, UIElementValue } from 'common/models/ui-element-interfaces';
 import { UnitService } from 'editor/src/app/services/unit.service';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-properties';
@@ -17,6 +17,17 @@ export class ElementPositionPropertiesComponent {
   @Input() dimensions!: Merged<DimensionProperties> | null | undefined;
   @Input() positionProperties: Merged<PositionProperties> | undefined;
   @Input() isZIndexDisabled: boolean = false;
+  /**
+   * Position edits go up to the host rather than into the `ElementService` from here. The host is
+   * the one place that evaluates `isInputValid`; writing directly meant the guard the field set
+   * computes could never take effect (#1154).
+   */
+  @Output() updatePositionModel =
+    new EventEmitter<{
+      property: keyof PositionProperties;
+      value: UIElementValue;
+      isInputValid?: boolean | null
+    }>();
 
   constructor(public unitService: UnitService,
               public selectionService: SelectionService,

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.html
@@ -16,7 +16,7 @@
         </ng-template>
         <aspect-ui-element-properties [combinedProperties]="combinedProperties"
                                       [selectedElements]="selectedElements"
-                                      (updateModel)="updateModel($event.property, $event.value)">
+                                      (updateModel)="updateModel($event.property, $event.value, $event.isInputValid)">
         </aspect-ui-element-properties>
       </mat-tab>
 
@@ -28,7 +28,8 @@
           <aspect-position-and-dimension-properties
             [dimensions]="combinedProperties.type === 'trigger' ? null : combinedProperties.dimensions"
             [positionProperties]="combinedProperties.position"
-            [isZIndexDisabled]="combinedProperties.type === 'trigger'">
+            [isZIndexDisabled]="combinedProperties.type === 'trigger'"
+            (updatePositionModel)="updatePositionModel($event.property, $event.value, $event.isInputValid)">
           </aspect-position-and-dimension-properties>
         </mat-tab>
       }

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
@@ -47,6 +47,10 @@ class MockElementPositionPropertiesComponent {
   @Input() dimensions!: DimensionProperties | null | undefined;
   @Input() positionProperties: PositionProperties | undefined;
   @Input() isZIndexDisabled: boolean = false;
+  /* Without this the binding in the host template is not an output at all - Angular quietly turns
+     an unknown one into a DOM event listener, and the test would pass with the argument missing. */
+  @Output() updatePositionModel =
+    new EventEmitter<{ property: string; value: UIElementValue, isInputValid?: boolean | null }>();
 }
 
 @Component({
@@ -435,6 +439,15 @@ describe('ElementPropertiesPanelComponent', () => {
       .toHaveBeenCalledWith([buttonElement], 'label', 'x');
   });
 
+  /* Asserted through the template rather than by calling the method: the binding is the thing that
+     used to drop the flag, and only the mock's real `@Output` makes it a binding at all. */
+  /* No template-level test for the position tab's binding, unlike the model tab's above.
+     Material attaches an inactive tab body's content on a transition event that never fires
+     without an animations module, which rule 3 rules out - the position tab simply cannot be
+     rendered through the host here. `properties-panel.characterization.spec.ts` hits the same wall
+     and lists it among its known gaps. The mock does declare `updatePositionModel` as a real
+     `@Output`, so the binding is at least wired to something rather than silently degrading to a
+     DOM event listener; the guard itself is covered by the two tests below. */
   it('should write a position property through the guard', () => {
     selectedElements.next([buttonElement]);
 

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.spec.ts
@@ -75,7 +75,8 @@ describe('ElementPropertiesPanelComponent', () => {
 
   beforeEach(async () => {
     elementService = createSpyObj<ElementService>(
-      ['updateElementsProperty', 'deleteElements', 'duplicateSelectedElements']
+      ['updateElementsProperty', 'updateSelectedElementsPositionProperty',
+        'deleteElements', 'duplicateSelectedElements']
     );
     messageService = createSpyObj<MessageService>(['showWarning', 'showError']);
     selectedElements = new BehaviorSubject<UIElement[]>([]);
@@ -402,6 +403,55 @@ describe('ElementPropertiesPanelComponent', () => {
     selectedElements.next([exploding]);
 
     expect(messageService.showError).toHaveBeenCalledTimes(2);
+  });
+
+  /* The leaves compute `isInputValid` and the host evaluates it, but the binding in between passed
+     only two arguments, so the parameter default `true` won every time and the whole validation
+     path was inert (#1154). Asserted through the template, because that binding is the defect. */
+  it('should carry isInputValid from the model tab to the guard', () => {
+    selectedElements.next([buttonElement]);
+    fixture.detectChanges();
+    const modelTab = fixture.debugElement
+      .query(debugElement => debugElement.componentInstance instanceof MockUIElementPropertiesComponent)
+      .componentInstance as MockUIElementPropertiesComponent;
+
+    modelTab.updateModel.emit({ property: 'label', value: 'x', isInputValid: false });
+
+    expect(elementService.updateElementsProperty).not.toHaveBeenCalled();
+    expect(messageService.showWarning).toHaveBeenCalled();
+  });
+
+  // Leaves that do not compute the flag must keep writing - the parameter default covers them.
+  it('should still write when a leaf sends no validity at all', () => {
+    selectedElements.next([buttonElement]);
+    fixture.detectChanges();
+    const modelTab = fixture.debugElement
+      .query(debugElement => debugElement.componentInstance instanceof MockUIElementPropertiesComponent)
+      .componentInstance as MockUIElementPropertiesComponent;
+
+    modelTab.updateModel.emit({ property: 'label', value: 'x' });
+
+    expect(elementService.updateElementsProperty)
+      .toHaveBeenCalledWith([buttonElement], 'label', 'x');
+  });
+
+  it('should write a position property through the guard', () => {
+    selectedElements.next([buttonElement]);
+
+    component.updatePositionModel('xPosition', 5);
+
+    expect(elementService.updateSelectedElementsPositionProperty)
+      .toHaveBeenCalledWith('xPosition', 5);
+    expect(messageService.showWarning).not.toHaveBeenCalled();
+  });
+
+  it('should warn instead of writing an invalid position property', () => {
+    selectedElements.next([buttonElement]);
+
+    component.updatePositionModel('xPosition', -1, false);
+
+    expect(elementService.updateSelectedElementsPositionProperty).not.toHaveBeenCalled();
+    expect(messageService.showWarning).toHaveBeenCalled();
   });
 
   it('should update the elements property for valid input', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-properties-panel/element-properties-panel.component.ts
@@ -8,6 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { MessageService } from 'editor/src/app/services/message.service';
 import { UIElement } from 'common/models/elements/element';
 import { LikertRowElement } from 'common/models/elements/compound-group-elements/likert/likert-row';
+import { PositionProperties } from 'common/models/elements/property-group-interfaces';
 import { ElementOverlay } from 'editor/src/app/directives/element-overlay.directive';
 import { ElementService } from 'editor/src/app/services/element.service';
 import { SectionService } from 'editor/src/app/services/section.service';
@@ -173,6 +174,21 @@ export class ElementPropertiesPanelComponent implements OnInit, OnDestroy {
   updateModel(property: string, value: UIElementValue, isInputValid: boolean | null = true): void {
     if (isInputValid) {
       this.elementService.updateElementsProperty(this.selectedElements, property, value);
+    } else {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+    }
+  }
+
+  /**
+   * The same guard for the position tab, which writes into a nested group and therefore cannot go
+   * through `updateModel`. It used to call the `ElementService` straight from its own template,
+   * which is how the `isInputValid` its field set computes got lost (#1154).
+   */
+  updatePositionModel(property: keyof PositionProperties,
+                      value: UIElementValue,
+                      isInputValid: boolean | null = true): void {
+    if (isInputValid) {
+      this.elementService.updateSelectedElementsPositionProperty(property, value);
     } else {
       this.messageService.showWarning(this.translateService.instant('inputInvalid'));
     }

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
@@ -12,9 +12,7 @@
       <input matInput type="number" #xPosition="ngModel" min="0"
              [ngModel]="positionProperties.xPosition"
              (ngModelChange)="updateModel.emit(
-                    { property: 'xPosition', value: $event, isInputValid: xPosition.valid && $event !== null })"
-             (change)="positionProperties.xPosition = positionProperties.xPosition ?
-                                                      positionProperties.xPosition : 0">
+                    { property: 'xPosition', value: $event ?? 0, isInputValid: xPosition.valid })">
     </mat-form-field>
     <mat-form-field *ngIf="positionProperties.yPosition !== undefined"
                     appearance="outline">
@@ -22,9 +20,7 @@
       <input matInput type="number" #yPosition="ngModel" min="0"
              [ngModel]="positionProperties.yPosition"
              (ngModelChange)="updateModel.emit(
-                    { property: 'yPosition', value: $event, isInputValid: yPosition.valid && $event !== null })"
-             (change)="positionProperties.yPosition = positionProperties.yPosition ?
-                                                      positionProperties.yPosition : 0">
+                    { property: 'yPosition', value: $event ?? 0, isInputValid: yPosition.valid })">
     </mat-form-field>
   </div>
 
@@ -113,9 +109,8 @@
       <input matInput type="number" #zIndex="ngModel"
              [ngModel]="positionProperties.zIndex"
              (ngModelChange)="updateModel.emit({ property: 'zIndex',
-                                                     value: $event,
-                                                     isInputValid: zIndex.valid && $event !== null })"
-             (change)="positionProperties.zIndex = positionProperties.zIndex ? positionProperties.zIndex : 0"
+                                                     value: $event ?? 0,
+                                                     isInputValid: zIndex.valid })"
              matTooltip="{{ 'propertiesPanel.zIndexTooltip' | translate }}">
     </mat-form-field>
   </ng-container>

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
@@ -13,8 +13,7 @@
              [ngModel]="positionProperties.xPosition"
              (ngModelChange)="$event !== null &&
                     updateModel.emit({ property: 'xPosition', value: $event, isInputValid: xPosition.valid })"
-             (change)="xPosition.value === null &&
-                    updateModel.emit({ property: 'xPosition', value: 0, isInputValid: true })">
+             (change)="commitNumber(xPosition, 'xPosition', positionProperties.xPosition)">
     </mat-form-field>
     <mat-form-field *ngIf="positionProperties.yPosition !== undefined"
                     appearance="outline">
@@ -23,8 +22,7 @@
              [ngModel]="positionProperties.yPosition"
              (ngModelChange)="$event !== null &&
                     updateModel.emit({ property: 'yPosition', value: $event, isInputValid: yPosition.valid })"
-             (change)="yPosition.value === null &&
-                    updateModel.emit({ property: 'yPosition', value: 0, isInputValid: true })">
+             (change)="commitNumber(yPosition, 'yPosition', positionProperties.yPosition)">
     </mat-form-field>
   </div>
 
@@ -42,8 +40,7 @@
                [ngModel]="positionProperties.gridRowRange" #gridRowRange="ngModel"
                (ngModelChange)="$event !== null &&
                     updateModel.emit({ property: 'gridRowRange', value: $event })"
-               (change)="gridRowRange.value === null &&
-                    updateModel.emit({ property: 'gridRowRange', value: 0 })">
+               (change)="commitNumber(gridRowRange, 'gridRowRange', positionProperties.gridRowRange)">
       </mat-form-field>
     </div>
     <div class="flex-row">
@@ -58,8 +55,7 @@
                [ngModel]="positionProperties.gridColumnRange" #gridColumnRange="ngModel"
                (ngModelChange)="$event !== null &&
                     updateModel.emit({ property: 'gridColumnRange', value: $event })"
-               (change)="gridColumnRange.value === null &&
-                    updateModel.emit({ property: 'gridColumnRange', value: 0 })">
+               (change)="commitNumber(gridColumnRange, 'gridColumnRange', positionProperties.gridColumnRange)">
       </mat-form-field>
     </div>
 
@@ -117,8 +113,7 @@
              (ngModelChange)="$event !== null && updateModel.emit({ property: 'zIndex',
                                                      value: $event,
                                                      isInputValid: zIndex.valid })"
-             (change)="zIndex.value === null &&
-                       updateModel.emit({ property: 'zIndex', value: 0, isInputValid: true })"
+             (change)="commitNumber(zIndex, 'zIndex', positionProperties.zIndex)"
              matTooltip="{{ 'propertiesPanel.zIndexTooltip' | translate }}">
     </mat-form-field>
   </ng-container>

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
@@ -11,16 +11,20 @@
       <mat-label>{{'propertiesPanel.xPosition' | translate }}</mat-label>
       <input matInput type="number" #xPosition="ngModel" min="0"
              [ngModel]="positionProperties.xPosition"
-             (ngModelChange)="updateModel.emit(
-                    { property: 'xPosition', value: $event ?? 0, isInputValid: xPosition.valid })">
+             (ngModelChange)="$event !== null &&
+                    updateModel.emit({ property: 'xPosition', value: $event, isInputValid: xPosition.valid })"
+             (change)="xPosition.value === null &&
+                    updateModel.emit({ property: 'xPosition', value: 0, isInputValid: true })">
     </mat-form-field>
     <mat-form-field *ngIf="positionProperties.yPosition !== undefined"
                     appearance="outline">
       <mat-label>{{'propertiesPanel.yPosition' | translate }}</mat-label>
       <input matInput type="number" #yPosition="ngModel" min="0"
              [ngModel]="positionProperties.yPosition"
-             (ngModelChange)="updateModel.emit(
-                    { property: 'yPosition', value: $event ?? 0, isInputValid: yPosition.valid })">
+             (ngModelChange)="$event !== null &&
+                    updateModel.emit({ property: 'yPosition', value: $event, isInputValid: yPosition.valid })"
+             (change)="yPosition.value === null &&
+                    updateModel.emit({ property: 'yPosition', value: 0, isInputValid: true })">
     </mat-form-field>
   </div>
 
@@ -35,10 +39,11 @@
       <mat-form-field appearance="outline">
         <mat-label>{{'propertiesPanel.rowRange' | translate }}</mat-label>
         <input matInput type="number"
-               [ngModel]="positionProperties.gridRowRange"
-               (ngModelChange)="updateModel.emit({ property: 'gridRowRange', value: $event })"
-               (change)="positionProperties.gridRowRange = positionProperties.gridRowRange ?
-                                                           positionProperties.gridRowRange : 0">
+               [ngModel]="positionProperties.gridRowRange" #gridRowRange="ngModel"
+               (ngModelChange)="$event !== null &&
+                    updateModel.emit({ property: 'gridRowRange', value: $event })"
+               (change)="gridRowRange.value === null &&
+                    updateModel.emit({ property: 'gridRowRange', value: 0 })">
       </mat-form-field>
     </div>
     <div class="flex-row">
@@ -50,10 +55,11 @@
       <mat-form-field appearance="outline">
         <mat-label>{{'propertiesPanel.columnRange' | translate }}</mat-label>
         <input matInput type="number"
-               [ngModel]="positionProperties.gridColumnRange"
-               (ngModelChange)="updateModel.emit({ property: 'gridColumnRange', value: $event })"
-               (change)="positionProperties.gridColumnRange = positionProperties.gridColumnRange ?
-                                                              positionProperties.gridColumnRange : 0">
+               [ngModel]="positionProperties.gridColumnRange" #gridColumnRange="ngModel"
+               (ngModelChange)="$event !== null &&
+                    updateModel.emit({ property: 'gridColumnRange', value: $event })"
+               (change)="gridColumnRange.value === null &&
+                    updateModel.emit({ property: 'gridColumnRange', value: 0 })">
       </mat-form-field>
     </div>
 
@@ -108,9 +114,11 @@
       <mat-label>{{'propertiesPanel.zIndex' | translate }}</mat-label>
       <input matInput type="number" #zIndex="ngModel"
              [ngModel]="positionProperties.zIndex"
-             (ngModelChange)="updateModel.emit({ property: 'zIndex',
-                                                     value: $event ?? 0,
+             (ngModelChange)="$event !== null && updateModel.emit({ property: 'zIndex',
+                                                     value: $event,
                                                      isInputValid: zIndex.valid })"
+             (change)="zIndex.value === null &&
+                       updateModel.emit({ property: 'zIndex', value: 0, isInputValid: true })"
              matTooltip="{{ 'propertiesPanel.zIndexTooltip' | translate }}">
     </mat-form-field>
   </ng-container>

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.html
@@ -11,8 +11,8 @@
       <mat-label>{{'propertiesPanel.xPosition' | translate }}</mat-label>
       <input matInput type="number" #xPosition="ngModel" min="0"
              [ngModel]="positionProperties.xPosition"
-             (ngModelChange)="$event !== null &&
-                    updateModel.emit({ property: 'xPosition', value: $event, isInputValid: xPosition.valid })"
+             (ngModelChange)="$event !== null && xPosition.valid &&
+                    updateModel.emit({ property: 'xPosition', value: $event })"
              (change)="commitNumber(xPosition, 'xPosition', positionProperties.xPosition)">
     </mat-form-field>
     <mat-form-field *ngIf="positionProperties.yPosition !== undefined"
@@ -20,8 +20,8 @@
       <mat-label>{{'propertiesPanel.yPosition' | translate }}</mat-label>
       <input matInput type="number" #yPosition="ngModel" min="0"
              [ngModel]="positionProperties.yPosition"
-             (ngModelChange)="$event !== null &&
-                    updateModel.emit({ property: 'yPosition', value: $event, isInputValid: yPosition.valid })"
+             (ngModelChange)="$event !== null && yPosition.valid &&
+                    updateModel.emit({ property: 'yPosition', value: $event })"
              (change)="commitNumber(yPosition, 'yPosition', positionProperties.yPosition)">
     </mat-form-field>
   </div>
@@ -38,7 +38,7 @@
         <mat-label>{{'propertiesPanel.rowRange' | translate }}</mat-label>
         <input matInput type="number"
                [ngModel]="positionProperties.gridRowRange" #gridRowRange="ngModel"
-               (ngModelChange)="$event !== null &&
+               (ngModelChange)="$event !== null && gridRowRange.valid &&
                     updateModel.emit({ property: 'gridRowRange', value: $event })"
                (change)="commitNumber(gridRowRange, 'gridRowRange', positionProperties.gridRowRange)">
       </mat-form-field>
@@ -53,7 +53,7 @@
         <mat-label>{{'propertiesPanel.columnRange' | translate }}</mat-label>
         <input matInput type="number"
                [ngModel]="positionProperties.gridColumnRange" #gridColumnRange="ngModel"
-               (ngModelChange)="$event !== null &&
+               (ngModelChange)="$event !== null && gridColumnRange.valid &&
                     updateModel.emit({ property: 'gridColumnRange', value: $event })"
                (change)="commitNumber(gridColumnRange, 'gridColumnRange', positionProperties.gridColumnRange)">
       </mat-form-field>
@@ -110,9 +110,8 @@
       <mat-label>{{'propertiesPanel.zIndex' | translate }}</mat-label>
       <input matInput type="number" #zIndex="ngModel"
              [ngModel]="positionProperties.zIndex"
-             (ngModelChange)="$event !== null && updateModel.emit({ property: 'zIndex',
-                                                     value: $event,
-                                                     isInputValid: zIndex.valid })"
+             (ngModelChange)="$event !== null && zIndex.valid &&
+                                 updateModel.emit({ property: 'zIndex', value: $event })"
              (change)="commitNumber(zIndex, 'zIndex', positionProperties.zIndex)"
              matTooltip="{{ 'propertiesPanel.zIndexTooltip' | translate }}">
     </mat-form-field>

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
@@ -92,19 +92,19 @@ describe('PositionFieldSetComponent', () => {
     xInput.value = '42';
     xInput.dispatchEvent(new Event('input'));
 
-    expect(emitted).toEqual([{ property: 'xPosition', value: 42, isInputValid: true }]);
+    expect(emitted).toEqual([{ property: 'xPosition', value: 42 }]);
   });
 
   /* Typing into a number field passes through states the accessor reports as null - an empty box,
      or a lone "-" the browser cannot parse yet. Anything emitted then is written and comes straight
-     back into the box through the model, stamping over what is being typed. Simulated here by
-     feeding the emitted value back the way the host does. */
+     back into the box through the model, stamping over what is being typed. The z-index carries no
+     `min`, so a negative value is legitimate and has to survive being typed. */
   it('should let a negative number be typed into the z-index', async () => {
     const emitted: { property: string; value: unknown }[] = [];
-    component.updateModel.subscribe(update => emitted.push(update));
-    component.positionProperties = { xPosition: 10, yPosition: 20, zIndex: -1 } as PositionProperties;
+    component.positionProperties = { xPosition: 10, yPosition: 20, zIndex: 3 } as PositionProperties;
     fixture.detectChanges();
     await fixture.whenStable();
+    component.updateModel.subscribe(update => emitted.push(update));
     const zInput = Array.from(
       fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
     ).at(-1) as HTMLInputElement;
@@ -113,16 +113,12 @@ describe('PositionFieldSetComponent', () => {
     zInput.value = '';
     zInput.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    // What the host would do with whatever was emitted.
-    if (emitted.length) {
-      component.positionProperties = {
-        ...component.positionProperties, zIndex: emitted[0].value
-      } as PositionProperties;
-      fixture.detectChanges();
-      await fixture.whenStable();
-    }
+    expect(emitted).toEqual([]); // a 0 written here would come back and overwrite the "-"
 
-    expect(zInput.value).not.toBe('0');
+    zInput.value = '-2';
+    zInput.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual([{ property: 'zIndex', value: -2 }]);
   });
 
   /* `xPosition` is declared `number`, so an emptied field must not send null down the write path -
@@ -172,23 +168,29 @@ describe('PositionFieldSetComponent', () => {
   });
 
   /* Now that the guard in the host actually rejects invalid input, the box must not keep showing a
-     number that was never saved. `min="0"` makes -5 invalid, nothing is written, and on leaving the
-     field the box goes back to the model value. */
-  it('should put a rejected value back to what the model holds', async () => {
+     number that was never saved. `min="0"` makes -5 invalid, nothing is written while it is typed,
+     and on leaving the field the box goes back to the model value.
+
+     The one emit is what makes the host warn. It carries `isInputValid: false`, so it is a report,
+     not a write - and it happens here rather than on the keystroke, or typing `-50` would warn
+     twice on its way through `-5`. */
+  it('should report a rejected value once and put the box back', async () => {
     const emitted: unknown[] = [];
     const xInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
-    xInput.value = '-5';
-    xInput.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    emitted.length = 0;
     component.updateModel.subscribe(update => emitted.push(update));
+    ['-5', '-50'].forEach(value => {
+      xInput.value = value;
+      xInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+    });
+    expect(emitted).toEqual([]); // nothing at all while it is being typed
 
     xInput.dispatchEvent(new Event('change'));
     fixture.detectChanges();
     await fixture.whenStable();
 
     expect(xInput.value).toBe('10');
-    expect(emitted).toEqual([]); // putting the box back is not a write
+    expect(emitted).toEqual([{ property: 'xPosition', value: -50, isInputValid: false }]);
   });
 
   // Leaving a field that holds a number must not write it a second time.

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
@@ -95,6 +95,36 @@ describe('PositionFieldSetComponent', () => {
     expect(emitted).toEqual([{ property: 'xPosition', value: 42, isInputValid: true }]);
   });
 
+  /* Typing into a number field passes through states the accessor reports as null - an empty box,
+     or a lone "-" the browser cannot parse yet. Anything emitted then is written and comes straight
+     back into the box through the model, stamping over what is being typed. Simulated here by
+     feeding the emitted value back the way the host does. */
+  it('should let a negative number be typed into the z-index', async () => {
+    const emitted: { property: string; value: unknown }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+    component.positionProperties = { xPosition: 10, yPosition: 20, zIndex: -1 } as PositionProperties;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const zInput = Array.from(
+      fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
+    ).at(-1) as HTMLInputElement;
+
+    // First keystroke of "-2": the browser cannot parse "-", the accessor reports null.
+    zInput.value = '';
+    zInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    // What the host would do with whatever was emitted.
+    if (emitted.length) {
+      component.positionProperties = {
+        ...component.positionProperties, zIndex: emitted[0].value
+      } as PositionProperties;
+      fixture.detectChanges();
+      await fixture.whenStable();
+    }
+
+    expect(zInput.value).not.toBe('0');
+  });
+
   /* `xPosition` is declared `number`, so an emptied field must not send null down the write path -
      that is how null reached the saved unit definition (#1154). An empty field means 0, and it
      stays a valid input, so it is written rather than warned about. A `(change)` handler used to
@@ -102,15 +132,56 @@ describe('PositionFieldSetComponent', () => {
 
      Note the contrast with the margin test below, where null is the right answer: there it means
      "the selected elements disagree", here it means "the user cleared the box". */
-  it('should emit zero rather than null for an emptied x position', () => {
+  it('should emit zero for an x position left empty, on leaving the field', () => {
     const emitted: { property: string; value: unknown, isInputValid?: boolean | null }[] = [];
     component.updateModel.subscribe(update => emitted.push(update));
-
     const xInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+
     xInput.value = '';
     xInput.dispatchEvent(new Event('input'));
+    expect(emitted).toEqual([]); // still mid-edit, nothing written
+
+    xInput.dispatchEvent(new Event('change'));
 
     expect(emitted).toEqual([{ property: 'xPosition', value: 0, isInputValid: true }]);
+  });
+
+  /* `gridRowRange` is declared `number` like the fields above, but it was left out of the first
+     round of this fix: it emitted the raw value, sent no validity, and kept a `(change)` handler
+     that patched `positionProperties` - the merged view object, not the element. The panel then
+     showed 0 while the saved unit definition held null (#1154). */
+  it('should emit zero for an emptied grid row range', async () => {
+    unitServiceMock.unit.pages[0].sections[0].dynamicPositioning = true;
+    const emitted: { property: string; value: unknown }[] = [];
+    component.positionProperties = {
+      gridRow: 1, gridRowRange: 2, gridColumn: 1, gridColumnRange: 2
+    } as PositionProperties;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    const rangeInput = Array.from(
+      fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
+    )[1];
+    rangeInput.value = '';
+    rangeInput.dispatchEvent(new Event('input'));
+    rangeInput.dispatchEvent(new Event('change'));
+
+    expect(emitted).toEqual([{ property: 'gridRowRange', value: 0 }]);
+    expect(component.positionProperties.gridRowRange).toBe(2); // the view object is not written to
+  });
+
+  // Leaving a field that holds a number must not write it a second time.
+  it('should not emit on leaving a field that has a value', () => {
+    const emitted: unknown[] = [];
+    const xInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    xInput.value = '7';
+    xInput.dispatchEvent(new Event('input'));
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    xInput.dispatchEvent(new Event('change'));
+
+    expect(emitted).toEqual([]);
   });
 
   /*

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
@@ -95,6 +95,24 @@ describe('PositionFieldSetComponent', () => {
     expect(emitted).toEqual([{ property: 'xPosition', value: 42, isInputValid: true }]);
   });
 
+  /* `xPosition` is declared `number`, so an emptied field must not send null down the write path -
+     that is how null reached the saved unit definition (#1154). An empty field means 0, and it
+     stays a valid input, so it is written rather than warned about. A `(change)` handler used to
+     patch the display to 0 afterwards; the value now arrives correct in the first place.
+
+     Note the contrast with the margin test below, where null is the right answer: there it means
+     "the selected elements disagree", here it means "the user cleared the box". */
+  it('should emit zero rather than null for an emptied x position', () => {
+    const emitted: { property: string; value: unknown, isInputValid?: boolean | null }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    const xInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    xInput.value = '';
+    xInput.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual([{ property: 'xPosition', value: 0, isInputValid: true }]);
+  });
+
   /*
    * A multi-selection whose margins disagree merges the measurement's parts to null. The panel has
    * to see that null - substituting 0 here would let it write a margin nobody entered.

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
@@ -167,8 +167,28 @@ describe('PositionFieldSetComponent', () => {
     rangeInput.dispatchEvent(new Event('input'));
     rangeInput.dispatchEvent(new Event('change'));
 
-    expect(emitted).toEqual([{ property: 'gridRowRange', value: 0 }]);
+    expect(emitted).toEqual([{ property: 'gridRowRange', value: 0, isInputValid: true }]);
     expect(component.positionProperties.gridRowRange).toBe(2); // the view object is not written to
+  });
+
+  /* Now that the guard in the host actually rejects invalid input, the box must not keep showing a
+     number that was never saved. `min="0"` makes -5 invalid, nothing is written, and on leaving the
+     field the box goes back to the model value. */
+  it('should put a rejected value back to what the model holds', async () => {
+    const emitted: unknown[] = [];
+    const xInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    xInput.value = '-5';
+    xInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    emitted.length = 0;
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    xInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(xInput.value).toBe('10');
+    expect(emitted).toEqual([]); // putting the box back is not a write
   });
 
   // Leaving a field that holds a number must not write it a second time.

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.ts
@@ -33,13 +33,18 @@ export class PositionFieldSetComponent {
    * - the box is empty. These properties are declared `number`, so an empty box means zero (#1154).
    *   Nothing is emitted while typing, because a box the browser cannot parse yet - a lone `-`,
    *   say - also reads as empty, and writing then stamps the value back over what is being typed.
-   * - the value is invalid, so the guard in the host refused it and the model still holds the old
-   *   one. The box has to follow, or it keeps showing a number that was never saved.
+   * - the value is invalid. Nothing was written while typing either, so the model still holds the
+   *   old one and the box has to follow, or it keeps showing a number that was never saved.
+   *
+   * Reporting the invalid value is what this method is for, rather than `ngModelChange`: typing
+   * `-50` passes through `-5`, and warning per keystroke put one warning on screen after the other
+   * for a single edit. One edit, one warning.
    */
   commitNumber(control: NgModel,
                property: keyof PositionProperties,
                modelValue: UIElementValue): void {
     if (control.invalid) {
+      this.updateModel.emit({ property, value: control.value, isInputValid: false });
       /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
          typing and emit the rejected value straight out again. */
       control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
+import { NgModel } from '@angular/forms';
 import { PositionProperties } from 'common/models/elements/property-group-interfaces';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import { UnitService } from 'editor/src/app/services/unit.service';
@@ -24,4 +25,26 @@ export class PositionFieldSetComponent {
     }>();
 
   constructor(public unitService: UnitService, public selectionService: SelectionService) {}
+
+  /**
+   * A number field has been left. Two things can be true then, and the emit on `ngModelChange`
+   * handles neither:
+   *
+   * - the box is empty. These properties are declared `number`, so an empty box means zero (#1154).
+   *   Nothing is emitted while typing, because a box the browser cannot parse yet - a lone `-`,
+   *   say - also reads as empty, and writing then stamps the value back over what is being typed.
+   * - the value is invalid, so the guard in the host refused it and the model still holds the old
+   *   one. The box has to follow, or it keeps showing a number that was never saved.
+   */
+  commitNumber(control: NgModel,
+               property: keyof PositionProperties,
+               modelValue: UIElementValue): void {
+    if (control.invalid) {
+      /* `emitViewToModelChange: false`, or putting the box back would itself look like the user
+         typing and emit the rejected value straight out again. */
+      control.control.setValue(modelValue, { emitViewToModelChange: false, emitEvent: false });
+      return;
+    }
+    if (control.value === null) this.updateModel.emit({ property, value: 0, isInputValid: true });
+  }
 }


### PR DESCRIPTION
Sieben Commits. Der Kern des Tickets ist klein — eine Flagge, die zwischen Blatt und Wirt verloren
ging. Was daran hing, war es nicht: der Validierungspfad war seit jeher wirkungslos, und ihn scharf
zu schalten hat drei Folgeprobleme sichtbar gemacht, von denen zwei erst durch diesen Branch
entstanden sind.

## Der gemeldete Defekt

Neun Bindungen im Panel rechnen aus, ob eine Eingabe gültig ist, und der Wirt wertet das aus.
Dazwischen ging die Flagge verloren — auf beiden Wegen, jeweils anders:

- `element-properties-panel.component.html` übergab `updateModel` nur zwei Argumente, der
  Parameter-Vorgabewert **gültig** gewann also jedes Mal.
- `element-position-properties.component.html` rief
  `elementService.updateSelectedElementsPositionProperty` direkt aus seinem eigenen Template auf und
  ging am Wirt vorbei — der Guard lag gar nicht auf dem Weg.

Der Positions-Tab schickt seine Änderungen jetzt nach oben; weil Positions-Properties in einer
verschachtelten Gruppe liegen und nicht durch `updateModel` können, hat der Wirt dafür einen
Geschwister-Guard bekommen. `messageService.showWarning('inputInvalid')` kann damit überhaupt zum
ersten Mal erscheinen.

## Was daran hing: das geleerte Zahlenfeld

Sechs Properties sind als `number` deklariert (`xPosition`, `yPosition`, `zIndex`, die
Schieberegler-Grenzen, die Lupengröße). Ein geleertes Feld schickte `null` — ein Typbruch, sobald er
das Modell und die gespeicherte Aufgabendefinition erreicht. Die Blätter waren sich darüber uneinig,
weshalb das Relais allein nicht gereicht hätte: ein leeres, nicht-erforderliches Zahlenfeld ist für
Angular **gültig**, null wäre also weiter durchgelaufen.

**Entscheidung (mit JHo): leer heißt 0.** Nicht bei `minLength`, `maxLength` und der
Schieberegler-Vorbelegung — dort ist leer die legitime Aussage „keine Grenze".

Dazu sind die alten `(change)`-Handler weg, die die Anzeige hinterher auf 0 zurückpatchten. Sie waren
der Grund, warum der falsche Wert unsichtbar blieb — und bei **einem** markierten Element waren sie
nicht bloß Anzeige: der Merge reicht die eigenen Objekte des Elements durch, sie schrieben also am
Service vorbei ins Modell. Gemessen: 42 → null (Service) → 0 (Blur-Handler).

## Drei Folgeprobleme, jedes mit eigenem Commit

**Die Null gehört an den Abschluss, nicht an jeden Tastendruck.** Meine eigene Regression aus dem
ersten Commit. Ein Zahlenfeld durchläuft beim Tippen Zustände, in denen der Accessor null meldet, weil
der Browser den Kasten noch nicht parsen kann. Die geschriebene 0 kam sofort zurück und stempelte
über das Getippte: ein `frame` hat `zIndex: -1`, aus getipptem `-2` wurde `2`. Eine X-Position von 300
zum Neutippen zu leeren schrieb erst 0 — das Element sprang sichtbar, ein Undo-Schritt wurde
aufgezeichnet — und ließ „050" im Feld stehen.

**Ein abgelehnter Wert blieb im Feld stehen.** Jetzt, wo der Guard wirklich ablehnt, warnt `-5` in
einem Feld mit `min="0"` und schreibt nichts — und der Kasten zeigte weiter `-5` über einem Element,
das noch an seiner alten Position stand. Beim Verlassen springt er auf den Modellwert zurück. Das
Zurückschreiben braucht `emitViewToModelChange: false`, sonst sieht es aus wie Tippen und schickt den
abgelehnten Wert gleich wieder los.

**Gewarnt wird einmal, beim Verlassen.** Aus einem dritten Review, und derselbe Fehler, den der Branch
bei der Null-Ersetzung schon einmal korrigiert hatte. Der Emit saß weiter auf `ngModelChange`, die
Warnung feuerte also pro Tastendruck: `-50` in die X-Position getippt warnt bei `-5` und nochmal bei
`-50`, und `MatSnackBar` ersetzt eine offene Meldung nicht, sondern reiht sich hinter deren Abbau ein
— eine einzige Eingabe legte zwei Warnungen à drei Sekunden nacheinander auf den Schirm. Der
Tastendruck schickt jetzt nur noch Gültiges, der ungültige Wert wird beim Verlassen einmal gemeldet.

## Der dritte Relais-Weg: die Größenfelder im Standardmodus

`StandardDimensionPropertiesComponent` schreibt — anders als jeder andere Tab — aus dem eigenen
Template in den `ElementService`, für sie hat also nie jemand Gültigkeit ausgewertet: `min="0"` stand
auf allen vier Kästen und bedeutete nichts, eine negative Breite wurde gespeichert. Zwei der vier
waren schlechter dran als das — Breite und Höhe der Geometrie schickten bei dem Tastendruck, der sie
leerte, `null` in ein `number`-Property, also genau der Defekt, um den dieser Branch geht.

Da die Komponente selbst schreibt, muss sie selbst prüfen: dieselbe `inputInvalid`-Warnung wie der
Wirt, `commitNumber` für Breite und Höhe, `revertIfInvalid` für `maxWidth` (`number | null`, leer
heißt „kein Maximum").

## Was bewusst offen bleibt

- **#1148** — `columnCount` ist hier mit erledigt (das Feld musste ohnehin angefasst werden und
  emittierte den rohen String von `input.value` in ein `number`-Property). Die anderen fünf sind
  unberührt, das Ticket bleibt dafür offen.
- **#1161** — `commitNumber` steht jetzt in vier Kopien, `revertIfInvalid` in zwei. Das
  Zusammenfassen zu einer gemeinsamen Direktive gehört zu #1161, das elf weitere Felder derselben
  Bauart anfasst. Ebenso der Aussehen-Tab, der an 28 Stellen genauso am Wirt vorbeischreibt, wie der
  Positions-Tab es tat.

## Grenze des Test-Setups, damit sie im Review nicht überrascht

Der Positions- und der Aussehen-Tab lassen sich im TestBed **nicht durch den Wirt rendern**: Material
hängt den Inhalt eines inaktiven Tabs an ein Transition-Event, das ohne Animations-Modul nie feuert —
und Regel 3 schließt das Modul aus. `properties-panel.characterization.spec.ts` führt dieselbe Lücke.
Der Mock deklariert `updatePositionModel` deshalb als echtes `@Output`, damit die Bindung nicht still
zu einem DOM-Event-Listener degradiert; der Guard selbst ist direkt getestet.

## Bitte ansehen

- X-Position leeren → speichert 0 beim Verlassen, das Element springt nicht mehr zwischendurch
- `-50` in die X-Position tippen → **eine** Warnung beim Verlassen, das Feld springt auf den alten Wert
- Standardmodus, Geometrie-Element: Breite leeren → 0; negative Höhe → abgelehnt, eine Warnung
- Maximalbreite leeren → bleibt leer (kein 0); negative Maximalbreite → abgelehnt
- Schieberegler-Grenzen: negative Werte müssen sich tippen lassen (dort gibt es kein `min`)

## Absicherung

- `ng test editor`: **785 Tests grün** (104 Dateien, 120 skipped), davon 20 neue in diesem Branch
- `ng build editor` sauber, ESLint ohne Errors auf allen geänderten Dateien
- Jeder Commit hat eine ausgeführte Gegenprobe, u. a. `expected '0' not to be '0'` für das
  Überschreiben beim Tippen und `called 1 times, but got 3 times`-Klasse für die Mehrfachwarnung

Refs #1154, refs #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
