### PR TITLE
Bad Input als Validierungsfehler statt als Sonderfall (#1161)

### DIFF
--- a/projects/editor/modules/editor-shared/directives/number-field-bad-input.directive.spec.ts
+++ b/projects/editor/modules/editor-shared/directives/number-field-bad-input.directive.spec.ts
@@ -1,0 +1,24 @@
+import { ElementRef } from '@angular/core';
+import { NumberFieldBadInputDirective } from './number-field-bad-input.directive';
+
+/**
+ * The contract only: what the directive answers for a given `validity.badInput`.
+ *
+ * That a browser sets the flag for `5e` at all, that it clears it again when the box is written to,
+ * and that the red border and the refusal follow from it - none of that can be shown here, because
+ * `badInput` is only ever set by real typing. Those are in the directive spec next door, under
+ * "with text the browser cannot read".
+ */
+describe('NumberFieldBadInputDirective', () => {
+  const withBadInput = (badInput: boolean): NumberFieldBadInputDirective => new NumberFieldBadInputDirective(
+    new ElementRef({ validity: { badInput } } as HTMLInputElement)
+  );
+
+  it('should report an error for text the browser could not read', () => {
+    expect(withBadInput(true).validate()).toEqual({ badInput: true });
+  });
+
+  it('should stay out of the way otherwise', () => {
+    expect(withBadInput(false).validate()).toBeNull();
+  });
+});

--- a/projects/editor/modules/editor-shared/directives/number-field-bad-input.directive.ts
+++ b/projects/editor/modules/editor-shared/directives/number-field-bad-input.directive.ts
@@ -1,0 +1,38 @@
+import { Directive, ElementRef, forwardRef } from '@angular/core';
+import { NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+
+/**
+ * Makes text the browser could not read count as invalid, like any other refused entry.
+ *
+ * A number input reports unreadable text and an empty box as the same thing - no value at all.
+ * `5e`, `1.2.3` or a decimal comma where the locale takes none leave `value` empty while the box
+ * goes on showing what was typed. Only `validity.badInput` keeps the difference, and it lives on
+ * the element rather than on the control, so nothing that reads the control alone can see it.
+ *
+ * Saying it as a validation error rather than as a special case in one place is what keeps the
+ * three parties that ask "is this refused?" in step: `NumberFieldDirective` when the field is left,
+ * the error state matcher while it is being typed in, and Material's own red border. Asked as a
+ * one-off it was only ever true in the first of them - an unreadable entry sat there looking
+ * accepted until the field was left, while the same keystrokes in a `required` box went red at once
+ * (#1161).
+ *
+ * A directive of its own, on the same selector, because the validator has to reach `NgModel` before
+ * `NgModel` is built: `NumberFieldDirective` injects `NgModel`, so it cannot also be one of the
+ * validators `NgModel` collects without a cycle.
+ */
+@Directive({
+  selector: 'input[type=number][ngModel][aspectNumberField]',
+  standalone: false,
+  providers: [{
+    provide: NG_VALIDATORS,
+    useExisting: forwardRef(() => NumberFieldBadInputDirective),
+    multi: true
+  }]
+})
+export class NumberFieldBadInputDirective implements Validator {
+  constructor(private element: ElementRef<HTMLInputElement>) {}
+
+  validate(): ValidationErrors | null {
+    return this.element.nativeElement.validity.badInput ? { badInput: true } : null;
+  }
+}

--- a/projects/editor/modules/editor-shared/directives/number-field-error-state.matcher.ts
+++ b/projects/editor/modules/editor-shared/directives/number-field-error-state.matcher.ts
@@ -14,10 +14,14 @@ import { ErrorStateMatcher } from '@angular/material/core';
  * mistake nobody made (#1161).
  *
  * `dirty` says the box was typed in, which is exactly when an empty one is the user's doing and
- * worth pointing at. It is also what the directive uses to decide whether leaving the field has
- * anything to answer for, and it clears the marker afterwards - so the red is live feedback while
- * an entry that would be refused stands in the box, and it goes when the entry does: leaving the
- * field puts the old value back, and the warning that follows says more than a red border can.
+ * worth pointing at. `invalid` covers text the browser could not read as well, because
+ * `NumberFieldBadInputDirective` says so as a validation error - otherwise `5e` would sit there
+ * looking accepted while the same keystrokes in a `required` box went red at once.
+ *
+ * `dirty` is also what the directive uses to decide whether leaving the field has anything to
+ * answer for, and it clears the marker afterwards - so the red is live feedback while an entry that
+ * would be refused stands in the box, and it goes when the entry does: leaving the field puts the
+ * old value back, and the warning that follows says more than a red border can.
  *
  * Provided by the directive itself, on the element - MatInput reads its default matcher from the
  * same node injector, so this reaches the boxes that carry the directive and nothing else.

--- a/projects/editor/modules/editor-shared/directives/number-field.directive.spec.ts
+++ b/projects/editor/modules/editor-shared/directives/number-field.directive.spec.ts
@@ -100,13 +100,16 @@ class RealInputHostComponent {
 }
 
 /* The same without `required`, for what the browser cannot read: only a box that may legitimately
-   be empty can mistake bad input for a clearing, and only real typing produces bad input at all. */
+   be empty can mistake bad input for a clearing, and only real typing produces bad input at all.
+   In a `mat-form-field`, because whether an unreadable entry looks refused is half the question. */
 @Component({
   standalone: false,
   template: `
-    <input id="box" type="number" min="0" aspectNumberField
-           [ngModel]="value"
-           (numberChange)="emitted.push($event)">
+    <mat-form-field>
+      <input id="box" matInput type="number" min="0" aspectNumberField
+             [ngModel]="value"
+             (numberChange)="emitted.push($event)">
+    </mat-form-field>
     <input id="other" type="text">
   `
 })
@@ -359,7 +362,6 @@ describe('NumberFieldDirective', () => {
 
     beforeEach(async () => {
       real = TestBed.createComponent(RealInputHostComponent);
-      document.body.appendChild(real.nativeElement);
       await settle();
     });
 
@@ -406,50 +408,68 @@ describe('NumberFieldDirective', () => {
 
       expect(real.componentInstance.emitted).toEqual([]);
     });
+  });
 
-    /* What the browser could not read is not the same as a box the user emptied, and only a box
-       that may be empty can confuse the two. `5e` is a half-typed exponent: `value` reads empty
-       while the box shows the text, so a maximum width would have come off, its checkbox unticked
-       and its field disabled, with nothing said. Measured, not assumed - `validity.badInput` is
-       only ever set by real typing, which is why this cannot be tested with dispatched events. */
-    it('should refuse what the browser could not read, rather than clear the property', async () => {
-      const optional = TestBed.createComponent(OptionalRealInputHostComponent);
-      document.body.appendChild(optional.nativeElement);
+  /* Text the browser could not read is not the same as a box the user emptied, and only a box that
+     may legitimately be empty can confuse the two. `5e` is a half-typed exponent: `value` reads
+     empty while the box shows the text, so a maximum width would have come off, its checkbox
+     unticked and its field disabled, with nothing said. `validity.badInput` is only ever set by
+     real typing, so none of this can be tested with dispatched events. */
+  describe('with text the browser cannot read', () => {
+    let optional: ComponentFixture<OptionalRealInputHostComponent>;
+
+    const box = (): HTMLInputElement => optional.nativeElement.querySelector('#box') as HTMLInputElement;
+    const other = (): HTMLInputElement => optional.nativeElement.querySelector('#other') as HTMLInputElement;
+    const isRed = (): boolean => !!optional.nativeElement.querySelector('.mat-form-field-invalid');
+    const settle = async (): Promise<void> => {
       optional.detectChanges();
       await optional.whenStable();
-      const halfTyped = optional.nativeElement.querySelector('#box') as HTMLInputElement;
+    };
 
-      await userEvent.click(halfTyped);
-      await userEvent.clear(halfTyped);
-      await userEvent.type(halfTyped, '5e');
-      optional.detectChanges();
-      expect(halfTyped.validity.badInput).toBe(true); // the state this exists for
+    beforeEach(async () => {
+      optional = TestBed.createComponent(OptionalRealInputHostComponent);
+      await settle();
+    });
 
-      await userEvent.click(optional.nativeElement.querySelector('#other') as HTMLInputElement);
-      optional.detectChanges();
-      await optional.whenStable();
+    it('should refuse it, rather than clear the property', async () => {
+      await userEvent.click(box());
+      await userEvent.clear(box());
+      await userEvent.type(box(), '5e');
+      await settle();
+      expect(box().validity.badInput).toBe(true); // the state this exists for
+
+      await userEvent.click(other());
+      await settle();
 
       expect(optional.componentInstance.emitted.at(-1)).toEqual({ value: null, isInputValid: false });
-      expect(halfTyped.value).toBe('300');
+      expect(box().value).toBe('300');
+    });
+
+    /* And it has to look refused while it stands there. The control cannot see bad input by itself,
+       so without the validator the box stayed neutral until the field was left - while the same
+       keystrokes in a `required` box went red at once. */
+    it('should look refused while it is still in the box', async () => {
+      await userEvent.click(box());
+      await userEvent.clear(box());
+      await userEvent.type(box(), '5e');
+      await settle();
+
+      expect(isRed()).toBe(true);
     });
 
     /* And the clearing it must not swallow: the same box, actually emptied, still reports null as a
-       value of its own. */
+       value of its own - and does not look refused, because it is not. */
     it('should still report a box that was really emptied', async () => {
-      const optional = TestBed.createComponent(OptionalRealInputHostComponent);
-      document.body.appendChild(optional.nativeElement);
-      optional.detectChanges();
-      await optional.whenStable();
-      const emptied = optional.nativeElement.querySelector('#box') as HTMLInputElement;
+      await userEvent.click(box());
+      await userEvent.clear(box());
+      await settle();
+      expect(isRed()).toBe(false);
 
-      await userEvent.click(emptied);
-      await userEvent.clear(emptied);
-      await userEvent.click(optional.nativeElement.querySelector('#other') as HTMLInputElement);
-      optional.detectChanges();
-      await optional.whenStable();
+      await userEvent.click(other());
+      await settle();
 
       expect(optional.componentInstance.emitted.at(-1)).toEqual({ value: null, isInputValid: true });
-      expect(emptied.value).toBe('');
+      expect(box().value).toBe('');
     });
   });
 
@@ -466,7 +486,6 @@ describe('NumberFieldDirective', () => {
 
     beforeEach(async () => {
       formField = TestBed.createComponent(FormFieldHostComponent);
-      document.body.appendChild(formField.nativeElement);
       await settle();
     });
 

--- a/projects/editor/modules/editor-shared/directives/number-field.directive.ts
+++ b/projects/editor/modules/editor-shared/directives/number-field.directive.ts
@@ -1,5 +1,5 @@
 import {
-  Directive, ElementRef, EventEmitter, HostListener, isDevMode, OnDestroy, OnInit, Output, Self
+  Directive, EventEmitter, HostListener, isDevMode, OnDestroy, OnInit, Output, Self
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
 import { ErrorStateMatcher } from '@angular/material/core';
@@ -62,24 +62,14 @@ export class NumberFieldDirective implements OnInit, OnDestroy {
 
   private ngUnsubscribe = new Subject<void>();
 
-  constructor(@Self() private ngModel: NgModel,
-              private element: ElementRef<HTMLInputElement>) {}
-
   /**
-   * Text the browser could not read as a number, as opposed to a box the user left empty.
-   *
-   * A number input reports both as no value at all - `5e`, `1.2.3` or a decimal comma where the
-   * locale does not take one leave `value` empty while the box goes on showing what was typed. The
-   * control cannot tell them apart, so without this a half-typed number would be committed as
-   * "cleared" wherever empty is a legitimate value: type `5e` into a maximum width and the limit
-   * would come off, the checkbox would untick and the field disable, with nothing said (#1161).
-   *
-   * `validity.badInput` is the only place the difference survives, and it is on the element rather
-   * than on the control - which is why the element is injected at all.
+   * Set when the call site binds two-way, which leaves the directive unable to do its job. See
+   * `ngOnInit`: in a built editor that is logged rather than thrown, and the directive then keeps
+   * out of the way entirely.
    */
-  private get isBadInput(): boolean {
-    return this.element.nativeElement.validity.badInput;
-  }
+  private isMisused = false;
+
+  constructor(@Self() private ngModel: NgModel) {}
 
   /**
    * What the model holds, i.e. the value bound through `[ngModel]`, untouched by typing.
@@ -100,12 +90,21 @@ export class NumberFieldDirective implements OnInit, OnDestroy {
 
        Thrown while developing, where it fires on the first render of the offending template and
        cannot be missed - but only logged in the built editor, because a template that slipped
-       through would otherwise take the whole panel or dialog down for the user. */
+       through would otherwise take the whole panel or dialog down for the user.
+
+       And then the directive stands down rather than half working. Carrying on would be worse than
+       doing nothing: `modelValue` reads what the banana box has already written, so the write-back
+       would put the refused value into the box while the caller is being told it was refused, and
+       the model would keep it too. Standing down leaves the field behaving as it did before the
+       directive was put on it. */
     if (this.ngModel.update.observed) {
       const misuse = 'aspectNumberField needs a one-way [ngModel] and reports through (numberChange): ' +
         'with [(ngModel)] or (ngModelChange) a refused value has already reached the caller.';
       if (isDevMode()) throw new Error(misuse);
+      // eslint-disable-next-line no-console -- a built editor has nowhere else to say this
       console.error(misuse);
+      this.isMisused = true;
+      return;
     }
 
     this.ngModel.update
@@ -136,10 +135,15 @@ export class NumberFieldDirective implements OnInit, OnDestroy {
    */
   @HostListener('blur')
   onLeave(): void {
+    if (this.isMisused) return;
+
     const control = this.ngModel.control;
     if (control.pristine) return;
 
-    if (control.invalid || this.isBadInput) {
+    /* Text the browser could not read counts as invalid here, which is not something the control
+       knows by itself - `NumberFieldBadInputDirective` puts it there, so that this, the red border
+       and Material all read the same answer. */
+    if (control.invalid) {
       this.numberChange.emit({ value: control.value as number | null, isInputValid: false });
       this.writeBack(this.modelValue);
     } else if (control.value === null) {

--- a/projects/editor/modules/editor-shared/directives/number-field.module.ts
+++ b/projects/editor/modules/editor-shared/directives/number-field.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { NumberFieldDirective } from './number-field.directive';
+import { NumberFieldBadInputDirective } from './number-field-bad-input.directive';
 
 /**
  * A module of its own so the directive has one owner and can be pulled into a spec's own host
@@ -10,7 +11,7 @@ import { NumberFieldDirective } from './number-field.directive';
  * neither of them.
  */
 @NgModule({
-  declarations: [NumberFieldDirective],
-  exports: [NumberFieldDirective]
+  declarations: [NumberFieldDirective, NumberFieldBadInputDirective],
+  exports: [NumberFieldDirective, NumberFieldBadInputDirective]
 })
 export class NumberFieldModule {}


### PR DESCRIPTION
Refs #1161. Nachtrag zu PR #1163 — drei Funde aus dem Review von `92f9e6cf`, dem einzigen Commit dieses Branches, der vor dem Merge nicht mehr angesehen worden war.

## Eine unlesbare Eingabe sah nicht abgelehnt aus

`validity.badInput` wurde an genau einer Stelle abgefragt: dort, wo beim Verlassen des Feldes entschieden wird. Der `ErrorStateMatcher` und Material fragen aber das Control, und das Control sieht Bad Input nicht.

Wo ein Feld leer sein darf, blieb es damit gültig: `5e` in einer „Maximalbreite" stand da, als wäre es angenommen, und schnappte erst beim Verlassen mit einer Warnung zurück — während dieselben Tastendrücke in einem `required`-Feld sofort rot wurden. Drei Beteiligte, die über dieselbe Eingabe unterschiedlicher Meinung waren; der Kommentar am Matcher versprach ausdrücklich das Gegenteil.

Jetzt ist es eine Validierungsfehlermeldung, beigetragen von `NumberFieldBadInputDirective` auf demselben Selektor. Damit lesen `onLeave`, der Matcher und Material dieselbe Antwort, und der Sonderfall in `onLeave` entfällt.

Warum eine eigene Direktive: `NumberFieldDirective` injiziert `NgModel`, und ein Validator muss `NgModel` erreichen, bevor `NgModel` gebaut wird. Beides in einer Klasse ist ein Zirkel.

## Der Missbrauchs-Guard hat in Produktion halb gearbeitet

Seit `92f9e6cf` wird bei `[(ngModel)]` nur noch im Entwicklungsmodus geworfen und im gebauten Editor geloggt — die Direktive machte danach aber weiter. Auf `blur` hieß das: dem Aufrufer wird „abgelehnt" gemeldet, und anschließend liest die Rückstellung den Modellwert, den die Zwei-Wege-Bindung längst mit dem abgelehnten Wert überschrieben hat. Der abgelehnte Wert landete also im Feld *und* blieb im Modell, während der Nutzer die Ablehnung angezeigt bekam.

Sie stellt sich jetzt ganz ab. Das Feld verhält sich dann wie vor dem Anbringen der Direktive, statt sich selbst zu widersprechen.

## Kleinkram

- `console.error` hat den `eslint-disable`-Kommentar bekommen, den die drei anderen Stellen im Editor auch tragen.
- `document.body.appendChild(fixture.nativeElement)` ist aus der Spec raus: das holt das Element aus TestBeds Root, dessen Aufräumen greift dann nicht mehr, und die liegengebliebenen Fixtures haben sich am Ende gegenseitig die Klicks abgefangen. Nötig war es nie — TestBed hängt die Fixture ohnehin ins Dokument.

## Prüfung

Alle fünf Testprojekte grün (2269 Tests), Lint und Production-Build sauber. Gegenprobe: ohne den Validator fallen genau die zwei neuen Bad-Input-Tests, der Test für das echte Leeren bleibt grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
