### PR TITLE
Die restlichen 23 Zahlenfelder hinter die Direktive (#1164)

### DIFF
--- a/docs/release-notes-editor.md
+++ b/docs/release-notes-editor.md
@@ -46,6 +46,12 @@ Editor
   - Das Feld "Stärke" im Bereich "Rahmen" setzte beim Verlassen den Radius zurück statt die Stärke zu übernehmen; beide Werte bleiben jetzt unabhängig voneinander
   - Bei gemeinsamer Markierung wirken diese Änderungen auf alle markierten Elemente
   - Auch in den Dialogen "Hotspot bearbeiten" und "Player-Einstellungen" werden unerlaubte oder leere Zahlen nicht mehr übernommen, mit demselben Hinweis "Eingabe ungültig" wie im Eigenschaftenbereich; dort ließen sich bislang z. B. negative Größen oder eine Lautstärke über 1 bestätigen. "Abstand von oben", "Abstand von links" und "Drehung" eines Hotspots dürfen dabei weiterhin negativ sein
+- Zahlenfelder außerhalb des Eigenschaftenbereichs
+  - Dieselbe Regel gilt jetzt auch im Seitenmenü ("Seitenbreite", "Randbreite", "Seitenverhältnis"), im Abschnittsmenü ("Höhe", "Anzahl der Zeilen"/"Spalten"), in den Dialogen "Bildgröße ändern" und "Sichtbarkeitsregeln" ("Verzögerung") sowie in den Assistenten (Antwortfelder, erwartete Zeichenanzahl, Bilder je Zeile, maximale Abspielhäufigkeit): eine unerlaubte oder leere Eingabe wird nicht mehr gespeichert, das Feld zeigt wieder den gespeicherten Wert und es erscheint einmal der Hinweis "Eingabe ungültig"
+  - Bislang wurde dort eine geleerte Eingabe als 0 gespeichert, und die angezeigten Grenzen (z. B. "mindestens 1") wurden nirgends durchgesetzt — eine Abspielhäufigkeit von 0 bedeutet im Player etwa "unbegrenzt", also das Gegenteil der Eingabe
+  - Die Zeilen- und Spaltenanzahl von Tabelle und Abschnitt lässt sich nicht mehr leeren: das löschte bisher alle Zeilen- bzw. Spaltendefinitionen auf einmal, ohne Rückfrage und ohne Hinweis
+  - Mehrere Felder speicherten die Eingabe als Text statt als Zahl (u. a. "Anzahl der Spalten", "Zeilenanzahl", "Spaltenverhältnis", Abschnittshöhe); die Aufgabendatei enthielt dort "5" statt 5
+  - Bei den Maßfeldern (Ränder, Zeilenhöhen, Spaltenbreiten) blieb ein geleertes Feld bisher stumm leer stehen, während der alte Wert gespeichert blieb; jetzt wird der gespeicherte Wert wieder angezeigt und der Hinweis erscheint. Negative Ränder bleiben erlaubt, negative Zeilen- und Spaltengrößen nicht
 
 ## 2.12.4
 ### Fehlerbehebungen 

--- a/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.html
+++ b/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.html
@@ -1,8 +1,11 @@
 <mat-form-field [style.width.%]="40">
   <mat-label>{{label}}</mat-label>
-  <input matInput type="number" [disabled]="disabled"
-         [(ngModel)]="value"
-         (change)="emitMeasurement()">
+  <input matInput type="number" required aspectNumberField
+         [disabled]="disabled"
+         [min]="min"
+         [ngModel]="value"
+         (numberChange)="commitValue($event)"
+         (blur)="applyValue()">
 </mat-form-field>
 <mat-form-field [style.width.%]="60">
   <mat-label>{{'section-menu.unit' | translate }}</mat-label>

--- a/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.html
+++ b/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.html
@@ -5,7 +5,8 @@
          [min]="min"
          [ngModel]="value"
          (numberChange)="commitValue($event)"
-         (blur)="applyValue()">
+         (blur)="applyValue()"
+         (keydown.enter)="applyValue()">
 </mat-form-field>
 <mat-form-field [style.width.%]="60">
   <mat-label>{{'section-menu.unit' | translate }}</mat-label>

--- a/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.spec.ts
+++ b/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.spec.ts
@@ -6,15 +6,24 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { TranslateModule } from '@ngx-translate/core';
 import { Measurement } from 'common/models/ui-element-interfaces';
+import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
+import { MessageService } from 'editor/src/app/services/message.service';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import { SizeInputPanelComponent } from './size-input-panel.component';
 
 describe('SizeInputPanelComponent', () => {
   let component: SizeInputPanelComponent;
   let fixture: ComponentFixture<SizeInputPanelComponent>;
+  let messageService: SpyObj<MessageService>;
 
   beforeEach(async () => {
+    messageService = createSpyObj<MessageService>(['showWarning']);
+
     await TestBed.configureTestingModule({
-      declarations: [SizeInputPanelComponent],
+      declarations: [SizeInputPanelComponent, NumberFieldDirective, NumberFieldBadInputDirective],
       imports: [
         CommonModule,
         FormsModule,
@@ -22,7 +31,8 @@ describe('SizeInputPanelComponent', () => {
         MatInputModule,
         MatSelectModule,
         TranslateModule.forRoot()
-      ]
+      ],
+      providers: [{ provide: MessageService, useValue: messageService }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(SizeInputPanelComponent);
@@ -81,22 +91,27 @@ describe('SizeInputPanelComponent', () => {
   });
 
   // A value entered into the empty field still reaches the whole selection.
-  it('should emit once the missing value is entered', () => {
+  it('should emit once the missing value is entered', async () => {
     let emitted: Measurement | undefined;
     component.valueUpdated.subscribe((measurement: Measurement) => { emitted = measurement; });
     component.value = null;
     fixture.detectChanges();
+    await fixture.whenStable();
 
     const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
     input.value = '5';
     input.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    input.dispatchEvent(new Event('change'));
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(emitted).toEqual({ value: 5, unit: 'fr' });
   });
 
-  it('should emit the combined measurement when the number input changes', () => {
+  /* On leaving the field, which is where the original `(change)` handler had it - so an edit
+     reaches the model once rather than once per keystroke. */
+  it('should emit the combined measurement when the number input is left', async () => {
     let emitted: Measurement | undefined;
     component.valueUpdated.subscribe((measurement: Measurement) => {
       emitted = measurement;
@@ -106,7 +121,11 @@ describe('SizeInputPanelComponent', () => {
     input.value = '7';
     input.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    input.dispatchEvent(new Event('change'));
+    expect(emitted).toBeUndefined(); // not while it is being typed
+
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(emitted).toEqual({ value: 7, unit: 'fr' });
   });
@@ -119,5 +138,57 @@ describe('SizeInputPanelComponent', () => {
 
     const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
     expect(input.disabled).toBe(true);
+  });
+
+  /* An emptied box wrote nothing - which is right, a measurement needs both halves - but it also
+     said nothing and put nothing back, so the field sat empty over a measurement that still held
+     its old value, and no later render brought it back (#1164). */
+  describe('leaving the number box', () => {
+    const box = (): HTMLInputElement => fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    const edit = async (value: string): Promise<void> => {
+      box().value = value;
+      box().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should put an emptied box back and say why', async () => {
+      let emitted: Measurement | undefined;
+      component.valueUpdated.subscribe((measurement: Measurement) => { emitted = measurement; });
+
+      await edit('');
+
+      expect(emitted).toBeUndefined();
+      expect(box().value).toBe('3');
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
+
+    /* The floor comes from the call site: this panel is a grid track size here, and a track shorter
+       than nothing is not a length. Where it serves a margin no floor is passed, because a negative
+       margin pulls the element up and is meant. */
+    it('should refuse a track size below the floor its call site gives it', async () => {
+      component.min = 0;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      let emitted: Measurement | undefined;
+      component.valueUpdated.subscribe((measurement: Measurement) => { emitted = measurement; });
+
+      await edit('-2');
+
+      expect(emitted).toBeUndefined();
+      expect(box().value).toBe('3');
+    });
+
+    it('should take a negative measurement where no floor is given', async () => {
+      let emitted: Measurement | undefined;
+      component.valueUpdated.subscribe((measurement: Measurement) => { emitted = measurement; });
+
+      await edit('-20');
+
+      expect(emitted).toEqual({ value: -20, unit: 'fr' });
+    });
   });
 });

--- a/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.spec.ts
+++ b/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.spec.ts
@@ -191,4 +191,80 @@ describe('SizeInputPanelComponent', () => {
       expect(emitted).toEqual({ value: -20, unit: 'fr' });
     });
   });
+
+  /* Enter is how a number gets confirmed without leaving the field, and the old `(change)` handler
+     fired on it. Hanging the write on `blur` alone silently dropped that: the box showed 15 and the
+     model kept the old value until the focus moved on (#1164). */
+  it('should write on Enter, not only on leaving the field', async () => {
+    let emitted: Measurement | undefined;
+    component.valueUpdated.subscribe((measurement: Measurement) => { emitted = measurement; });
+    const box = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    box.value = '15';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual({ value: 15, unit: 'fr' });
+  });
+
+  /* And then not a second time when the field is left: what was pending has been used up. */
+  it('should not write the same entry twice after Enter', async () => {
+    let emits = 0;
+    component.valueUpdated.subscribe(() => { emits += 1; });
+    const box = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    box.value = '15';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+    box.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emits).toBe(1);
+  });
+
+  /* A refused entry has to drop what an earlier keystroke made pending, or leaving the field would
+     warn and write the deleted value anyway. This is what pins the order the whole pending scheme
+     rests on: the directive's blur listener runs before the template's. */
+  it('should not write a value that was typed and then deleted again', async () => {
+    let emitted: Measurement | undefined;
+    component.valueUpdated.subscribe((measurement: Measurement) => { emitted = measurement; });
+    const box = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    box.value = '5';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    box.value = '';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    box.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toBeUndefined();
+    expect(box.value).toBe('3');
+    expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+  });
+
+  /* Retyping what is already there is not an edit. The old `(change)` handler did not fire for it,
+     because the value at blur equalled the value at focus. */
+  it('should not write an entry that changes nothing', async () => {
+    let emits = 0;
+    component.valueUpdated.subscribe(() => { emits += 1; });
+    const box = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    box.value = '3';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    box.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emits).toBe(0);
+  });
 });

--- a/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.ts
+++ b/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.ts
@@ -1,7 +1,9 @@
 import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { Measurement } from 'common/models/ui-element-interfaces';
+import { MessageService } from 'editor/src/app/services/message.service';
 
 @Component({
   selector: 'aspect-size-input-panel',
@@ -16,7 +18,51 @@ export class SizeInputPanelComponent {
   @Input() unit: string | null | undefined;
   @Input() allowedUnits!: string[];
   @Input() disabled!: boolean;
+  /**
+   * The smallest measurement this call site accepts, or null for no floor.
+   *
+   * It has to come from the call site because the same panel serves two kinds of measurement: a
+   * margin goes into CSS `margin-top`, where a negative value pulls the element up and is meant,
+   * while a grid track size of less than zero is not a length at all (#1164).
+   */
+  @Input() min: number | null = null;
   @Output() valueUpdated = new EventEmitter<Measurement>();
+
+  /** The last valid entry in the number box, applied when the field is left. */
+  private pendingValue: number | null = null;
+
+  constructor(private messageService: MessageService,
+              private translateService: TranslateService) {}
+
+  /**
+   * What `aspectNumberField` worked out for the number half of the measurement.
+   *
+   * An emptied box wrote nothing - correctly, see below - but also said nothing and put nothing
+   * back, so the field sat empty over a measurement that still held its old value, and no later
+   * render brought it back. Measured (#1164).
+   */
+  commitValue(update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      this.pendingValue = null;
+      return;
+    }
+    this.pendingValue = update.value;
+  }
+
+  /**
+   * Written when the field is left, which is where the original `(change)` handler had it - so an
+   * edit still reaches the model once rather than once per keystroke.
+   *
+   * The directive's own blur listener runs first, so a refused entry has already cleared what was
+   * pending by the time this asks.
+   */
+  applyValue(): void {
+    if (this.pendingValue === null) return;
+    this.value = this.pendingValue;
+    this.pendingValue = null;
+    this.emitMeasurement();
+  }
 
   /**
    * A measurement is written only once both of its parts are there.

--- a/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.ts
+++ b/projects/editor/modules/editor-shared/components/size-input-panel/size-input-panel.component.ts
@@ -42,6 +42,8 @@ export class SizeInputPanelComponent {
    * render brought it back. Measured (#1164).
    */
   commitValue(update: { value: number | null; isInputValid: boolean }): void {
+    // The box is `required`, so a valid update always carries a number - the null check is
+    // what narrows the type, not a case that can occur.
     if (!update.isInputValid || update.value === null) {
       this.messageService.showWarning(this.translateService.instant('inputInvalid'));
       this.pendingValue = null;
@@ -59,6 +61,13 @@ export class SizeInputPanelComponent {
    */
   applyValue(): void {
     if (this.pendingValue === null) return;
+    /* Retyping what is already there is not an edit, and the original `(change)` handler did not
+       fire for it either - a `change` event only comes when the value at blur differs from the one
+       at focus. Without this, selecting a 3 and typing 3 wrote a fresh measurement to the model. */
+    if (this.pendingValue === this.value) {
+      this.pendingValue = null;
+      return;
+    }
     this.value = this.pendingValue;
     this.pendingValue = null;
     this.emitMeasurement();

--- a/projects/editor/modules/section-templates/components/radio/image-radio/image-radio.component.html
+++ b/projects/editor/modules/section-templates/components/radio/image-radio/image-radio.component.html
@@ -10,7 +10,10 @@
 
 <h3>Bilder je Zeile</h3>
 <mat-form-field [style.align-self]="'flex-start'">
-  <input matInput type="number" min="1" max="9" [style.margin-left]="'unset'" [(ngModel)]="options.itemsPerRow">
+  <input matInput type="number" min="1" max="9" required aspectNumberField
+         [style.margin-left]="'unset'"
+         [ngModel]="options.itemsPerRow"
+         (numberChange)="commitItemsPerRow($event)">
 </mat-form-field>
 <p>4 Bilder pro Zeile: empfohlen für kleine Bilder oder einseitige Aufgaben<br>
   2 Bilder pro Zeile: empfohlen für zweiseitige Aufgaben oder große Bilder</p>

--- a/projects/editor/modules/section-templates/components/radio/image-radio/image-radio.component.spec.ts
+++ b/projects/editor/modules/section-templates/components/radio/image-radio/image-radio.component.spec.ts
@@ -8,7 +8,14 @@ import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { TranslateModule } from '@ngx-translate/core';
 import { TextImageLabel } from 'common/models/label-interfaces';
+import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
+import { MessageService } from 'editor/src/app/services/message.service';
 import {
   ImageRadioComponent
 } from 'editor/modules/section-templates/components/radio/image-radio/image-radio.component';
@@ -41,24 +48,31 @@ class MockOptionListPanelComponent {
 describe('ImageRadioComponent', () => {
   let component: ImageRadioComponent;
   let fixture: ComponentFixture<ImageRadioComponent>;
+  let messageService: SpyObj<MessageService>;
 
   const createLabel = (text: string): TextImageLabel => ({
     text, imgSrc: null, imgFileName: '', imgPosition: 'above'
   });
 
   beforeEach(async () => {
+    messageService = createSpyObj<MessageService>(['showWarning']);
+
     await TestBed.configureTestingModule({
       declarations: [
         ImageRadioComponent,
         MockRichTextEditorComponent,
-        MockOptionListPanelComponent
+        MockOptionListPanelComponent,
+        NumberFieldDirective,
+        NumberFieldBadInputDirective
       ],
       imports: [
         FormsModule,
         MatCheckboxModule,
         MatFormFieldModule,
-        MatInputModule
-      ]
+        MatInputModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [{ provide: MessageService, useValue: messageService }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ImageRadioComponent);
@@ -103,5 +117,43 @@ describe('ImageRadioComponent', () => {
     (optionListPanel.componentInstance as MockOptionListPanelComponent).itemListUpdated.emit();
 
     expect(checkValiditySpy).toHaveBeenCalled();
+  });
+
+  /* `min="1" max="9"` sat on the box and nothing enforced them, and the binding was two-way - so an
+     emptied box or a 0 went into the generated section, where it becomes the column count of the
+     radio group (#1164). */
+  describe('the images-per-row box', () => {
+    const box = (): HTMLInputElement => fixture.nativeElement
+      .querySelector('input[type="number"]') as HTMLInputElement;
+
+    const edit = async (value: string): Promise<void> => {
+      box().value = value;
+      box().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should take an edited count', async () => {
+      await edit('2');
+
+      expect(component.options.itemsPerRow).toBe(2);
+    });
+
+    it('should refuse a count above the maximum and put the box back', async () => {
+      await edit('12');
+
+      expect(component.options.itemsPerRow).toBe(4);
+      expect(box().value).toBe('4');
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refuse an emptied count', async () => {
+      await edit('');
+
+      expect(component.options.itemsPerRow).toBe(4);
+      expect(box().value).toBe('4');
+    });
   });
 });

--- a/projects/editor/modules/section-templates/components/radio/image-radio/image-radio.component.ts
+++ b/projects/editor/modules/section-templates/components/radio/image-radio/image-radio.component.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Output } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { ImageRadioOptions } from 'editor/modules/section-templates/models/radio-interfaces';
+import { MessageService } from 'editor/src/app/services/message.service';
 
 @Component({
   standalone: false,
@@ -18,6 +20,24 @@ export class ImageRadioComponent {
     text1: 'Begründe deine Entscheidung.',
     extraInputMathfield: false
   };
+
+  constructor(private messageService: MessageService,
+              private translateService: TranslateService) {}
+
+  /**
+   * What `aspectNumberField` worked out for the images-per-row box.
+   *
+   * `min="1" max="9"` sat on it and nothing enforced them, and the binding was two-way - so an
+   * emptied box or a 0 went into the generated section, where it becomes the column count of the
+   * radio group (#1164).
+   */
+  commitItemsPerRow(update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      return;
+    }
+    this.options.itemsPerRow = update.value;
+  }
 
   checkValidity(): void {
     if (this.options.options.length > 1) {

--- a/projects/editor/modules/section-templates/components/stimulus/audio-row/audio-row.component.html
+++ b/projects/editor/modules/section-templates/components/stimulus/audio-row/audio-row.component.html
@@ -6,5 +6,7 @@
 </button>
 <mat-form-field appearance="outline">
   <mat-label>Maximale Abspielhäufigkeit</mat-label>
-  <input matInput type="number" min="1" [(ngModel)]="maxRuns" (ngModelChange)="maxRunsChange.emit($event)">
+  <input matInput type="number" min="1" required aspectNumberField
+         [ngModel]="maxRuns"
+         (numberChange)="commitMaxRuns($event)">
 </mat-form-field>

--- a/projects/editor/modules/section-templates/components/stimulus/audio-row/audio-row.component.spec.ts
+++ b/projects/editor/modules/section-templates/components/stimulus/audio-row/audio-row.component.spec.ts
@@ -5,6 +5,13 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
+import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
+import { MessageService } from 'editor/src/app/services/message.service';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import {
   AudioRowComponent
 } from 'editor/modules/section-templates/components/stimulus/audio-row/audio-row.component';
@@ -12,18 +19,23 @@ import {
 describe('AudioRowComponent', () => {
   let component: AudioRowComponent;
   let fixture: ComponentFixture<AudioRowComponent>;
+  let messageService: SpyObj<MessageService>;
 
   beforeEach(async () => {
+    messageService = createSpyObj<MessageService>(['showWarning']);
+
     await TestBed.configureTestingModule({
-      declarations: [AudioRowComponent],
+      declarations: [AudioRowComponent, NumberFieldDirective, NumberFieldBadInputDirective],
       imports: [
         FormsModule,
         MatButtonModule,
         MatFormFieldModule,
         MatIconModule,
         MatInputModule,
-        MatTooltipModule
-      ]
+        MatTooltipModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [{ provide: MessageService, useValue: messageService }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(AudioRowComponent);
@@ -63,5 +75,25 @@ describe('AudioRowComponent', () => {
     fixture.detectChanges();
 
     expect(emitSpy).toHaveBeenCalledWith(5);
+  });
+
+  /* `min="1"` was on the box and enforced nowhere, and the binding was two-way: a 0 or an emptied
+     box reached the generated element, where 0 means "no limit" to the player - the opposite of
+     what the box asks for (#1164). */
+  it('should refuse a play count below the minimum and put the box back', async () => {
+    const emitSpy = vi.spyOn(component.maxRunsChange, 'emit');
+    const input = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+
+    input.value = '0';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(component.maxRuns).toBe(1);
+    expect(input.value).toBe('1');
+    expect(messageService.showWarning).toHaveBeenCalledTimes(1);
   });
 });

--- a/projects/editor/modules/section-templates/components/stimulus/audio-row/audio-row.component.ts
+++ b/projects/editor/modules/section-templates/components/stimulus/audio-row/audio-row.component.ts
@@ -1,6 +1,8 @@
 import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { MessageService } from 'editor/src/app/services/message.service';
 
 @Component({
   standalone: false,
@@ -13,4 +15,23 @@ export class AudioRowComponent {
   @Input() maxRuns!: number;
   @Output() maxRunsChange = new EventEmitter<number>();
   @Output() changeMediaSrc = new EventEmitter();
+
+  constructor(private messageService: MessageService,
+              private translateService: TranslateService) {}
+
+  /**
+   * What `aspectNumberField` worked out for the play count.
+   *
+   * The binding was two-way and `min="1"` was never enforced, so a 0 or an emptied box reached the
+   * generated element - where 0 means "no limit" to the player, the opposite of what the box says
+   * (#1164).
+   */
+  commitMaxRuns(update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      return;
+    }
+    this.maxRuns = update.value;
+    this.maxRunsChange.emit(update.value);
+  }
 }

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
@@ -6,7 +6,9 @@
 
   <h3>Anzahl Antwortfelder</h3>
   <mat-form-field class="align-start">
-    <input matInput type="number" min="1" max="9" [(ngModel)]="answerCount" (change)="updateSubQuestions()">
+    <input matInput type="number" min="1" max="9" required aspectNumberField
+           [ngModel]="answerCount"
+           (numberChange)="commitAnswerCount($event)">
   </mat-form-field>
 
   <h3>Nummerierung</h3>
@@ -51,8 +53,9 @@
     <ng-container *ngIf="multilineInputs">
       <mat-form-field [style]="'width: 270px;'">
         <mat-label>Erwartete Zeichenanzahl</mat-label>
-        <input matInput type="number" maxlength="4"
-               [(ngModel)]="expectedCharsCount" [disabled]="!multilineInputs">
+        <input matInput type="number" min="1" required aspectNumberField
+               [ngModel]="expectedCharsCount" [disabled]="!multilineInputs"
+               (numberChange)="commitExpectedCharsCount($event)">
       </mat-form-field>
     </ng-container>
   </div>

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
@@ -8,7 +8,8 @@
   <mat-form-field class="align-start">
     <input matInput type="number" min="1" max="9" required aspectNumberField
            [ngModel]="answerCount"
-           (numberChange)="commitAnswerCount($event)">
+           (numberChange)="commitAnswerCount($event)"
+           (blur)="applyAnswerCount()">
   </mat-form-field>
 
   <h3>Nummerierung</h3>

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
@@ -9,7 +9,8 @@
     <input matInput type="number" min="1" max="9" required aspectNumberField
            [ngModel]="answerCount"
            (numberChange)="commitAnswerCount($event)"
-           (blur)="applyAnswerCount()">
+           (blur)="applyAnswerCount()"
+           (keydown.enter)="applyAnswerCount()">
   </mat-form-field>
 
   <h3>Nummerierung</h3>

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.html
@@ -15,7 +15,7 @@
 
   <h3>Nummerierung</h3>
   <mat-form-field class="align-start">
-    <mat-select [disabled]="answerCount < 2" [(ngModel)]="numbering">
+    <mat-select [disabled]="!numberingAvailable" [(ngModel)]="numbering">
       <mat-option [value]="'latin'">a), b), ...</mat-option>
       <mat-option [value]="'decimal'">1), 2), ...</mat-option>
       <mat-option [value]="'bullets'">&#x2022;, &#x2022;, ...</mat-option>

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.spec.ts
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.spec.ts
@@ -12,6 +12,12 @@ import { MatInputModule } from '@angular/material/input';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { TranslateModule } from '@ngx-translate/core';
+import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
+import { MessageService } from 'editor/src/app/services/message.service';
 import {
   InputWizardDialogComponent
 } from 'editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component';
@@ -30,6 +36,7 @@ class MockRichTextEditorComponent {
 describe('InputWizardDialogComponent', () => {
   let component: InputWizardDialogComponent;
   let fixture: ComponentFixture<InputWizardDialogComponent>;
+  let messageService: SpyObj<MessageService>;
 
   const mockDialogRef = {
     close: vi.fn()
@@ -38,10 +45,14 @@ describe('InputWizardDialogComponent', () => {
   beforeEach(async () => {
     mockDialogRef.close.mockClear();
 
+    messageService = createSpyObj<MessageService>(['showWarning']);
+
     await TestBed.configureTestingModule({
       declarations: [
         InputWizardDialogComponent,
-        MockRichTextEditorComponent
+        MockRichTextEditorComponent,
+        NumberFieldDirective,
+        NumberFieldBadInputDirective
       ],
       imports: [
         CommonModule,
@@ -56,7 +67,8 @@ describe('InputWizardDialogComponent', () => {
         TranslateModule.forRoot()
       ],
       providers: [
-        { provide: MatDialogRef, useValue: mockDialogRef }
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MessageService, useValue: messageService }
       ]
     }).compileComponents();
 
@@ -139,6 +151,47 @@ describe('InputWizardDialogComponent', () => {
       useMathFields: false,
       numberingWithText: false,
       subQuestions: []
+    });
+  });
+
+  /* Both number boxes were bound two-way with a `min`/`max` that nothing enforced: `answerCount`
+     decides how many answer fields the wizard generates and how long the sub-question array is, so
+     an emptied box or a 0 reached that logic directly (#1164). */
+  describe('the answer count box', () => {
+    const box = (): HTMLInputElement => fixture.nativeElement
+      .querySelector('input[type="number"]') as HTMLInputElement;
+
+    const edit = async (value: string): Promise<void> => {
+      box().value = value;
+      box().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should take an edited count and rebuild the sub-questions', async () => {
+      component.numberingWithText = true;
+
+      await edit('3');
+
+      expect(component.answerCount).toBe(3);
+      expect(component.subQuestions.length).toBe(3);
+    });
+
+    it('should refuse a count above the maximum and put the box back', async () => {
+      await edit('12');
+
+      expect(component.answerCount).toBe(1);
+      expect(box().value).toBe('1');
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refuse an emptied count', async () => {
+      await edit('');
+
+      expect(component.answerCount).toBe(1);
+      expect(box().value).toBe('1');
     });
   });
 });

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.spec.ts
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.spec.ts
@@ -179,6 +179,43 @@ describe('InputWizardDialogComponent', () => {
       expect(component.subQuestions.length).toBe(3);
     });
 
+    /* The numbering beside the box may only be chosen for more than one answer field. Because the
+       count itself is applied on leaving, the control has to follow the pending entry instead - or
+       it stays disabled while the author is still in the box, and reaching for it does nothing.
+       Found by the e2e suite, which could not click it. */
+    it('should offer the numbering as soon as a second field is typed', async () => {
+      const numbering = (): HTMLElement => fixture.nativeElement
+        .querySelector('mat-select') as HTMLElement;
+      // NgModel applies the disabled state in a microtask, and MatSelect renders it on the run after
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(numbering().getAttribute('aria-disabled')).toBe('true');
+
+      box().value = '3';
+      box().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(numbering().getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('should take the numbering away again when the entry is refused', async () => {
+      box().value = '3';
+      box().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box().value = '30';
+      box().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const numbering = fixture.nativeElement.querySelector('mat-select') as HTMLElement;
+      expect(numbering.getAttribute('aria-disabled')).toBe('true');
+    });
+
     it('should refuse a count above the maximum and put the box back', async () => {
       await edit('12');
 

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.spec.ts
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.spec.ts
@@ -194,4 +194,32 @@ describe('InputWizardDialogComponent', () => {
       expect(box().value).toBe('1');
     });
   });
+
+  /* `max="9"` means every two-digit entry passes through a valid single digit. Applying that digit
+     at once shortened `subQuestions` to it and the texts beyond were gone - selecting a 5 and
+     typing 15 left one answer field, four lost texts and a 1 in the box (#1164). */
+  it('should not shorten the sub-questions while a two-digit count is being typed', async () => {
+    component.numberingWithText = true;
+    component.answerCount = 5;
+    component.subQuestions = ['a', 'b', 'c', 'd', 'e'];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const box = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+
+    box.value = '1';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(component.subQuestions).toEqual(['a', 'b', 'c', 'd', 'e']); // nothing yet
+
+    box.value = '15';
+    box.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    box.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.answerCount).toBe(5);
+    expect(component.subQuestions).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(box.value).toBe('5');
+  });
 });

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.ts
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { MessageService } from 'editor/src/app/services/message.service';
 
 @Component({
   standalone: false,
@@ -16,6 +18,33 @@ export class InputWizardDialogComponent {
   multilineInputs: boolean = false;
   expectedCharsCount: number = 90;
   useMathFields: boolean = false;
+
+  constructor(private messageService: MessageService,
+              private translateService: TranslateService) {}
+
+  /**
+   * What `aspectNumberField` worked out for the two number boxes.
+   *
+   * Both were bound two-way with a `min`/`max` that nothing enforced, so an emptied box or a 0
+   * reached the wizard: `answerCount` decides how many answer fields are generated and how long the
+   * sub-question array is, `expectedCharsCount` sizes the generated field (#1164).
+   */
+  commitAnswerCount(update: { value: number | null; isInputValid: boolean }): void {
+    if (!this.accept(update)) return;
+    this.answerCount = update.value as number;
+    this.updateSubQuestions();
+  }
+
+  commitExpectedCharsCount(update: { value: number | null; isInputValid: boolean }): void {
+    if (!this.accept(update)) return;
+    this.expectedCharsCount = update.value as number;
+  }
+
+  private accept(update: { value: number | null; isInputValid: boolean }): boolean {
+    if (update.isInputValid && update.value !== null) return true;
+    this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+    return false;
+  }
 
   updateSubQuestions() {
     if (!this.numberingWithText) {

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.ts
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.ts
@@ -19,6 +19,9 @@ export class InputWizardDialogComponent {
   expectedCharsCount: number = 90;
   useMathFields: boolean = false;
 
+  /** The last valid entry in the answer count box, applied when the field is left. */
+  private pendingAnswerCount: number | null = null;
+
   constructor(private messageService: MessageService,
               private translateService: TranslateService) {}
 
@@ -30,8 +33,28 @@ export class InputWizardDialogComponent {
    * sub-question array is, `expectedCharsCount` sizes the generated field (#1164).
    */
   commitAnswerCount(update: { value: number | null; isInputValid: boolean }): void {
-    if (!this.accept(update)) return;
-    this.answerCount = update.value as number;
+    if (!this.accept(update)) {
+      this.pendingAnswerCount = null;
+      return;
+    }
+    this.pendingAnswerCount = update.value as number;
+  }
+
+  /**
+   * The count is applied on leaving the field, not on the keystroke, and that is load-bearing.
+   *
+   * `max="9"` means every two-digit entry passes through a valid single digit first. Applying that
+   * digit shortens `subQuestions` to it, and the texts beyond are gone - so selecting a 5 and typing
+   * 15 left one answer field and four lost texts, with the box put back to 1 rather than 5, because
+   * the model had already followed the 1. The original handler was on `(change)`, i.e. here.
+   *
+   * The directive's own blur listener runs first (measured), so a refused entry has already cleared
+   * what was pending by the time this asks.
+   */
+  applyAnswerCount(): void {
+    if (this.pendingAnswerCount === null) return;
+    this.answerCount = this.pendingAnswerCount;
+    this.pendingAnswerCount = null;
     this.updateSubQuestions();
   }
 

--- a/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.ts
+++ b/projects/editor/modules/section-templates/components/text-input-dialog/text-input-dialog.component.ts
@@ -19,6 +19,16 @@ export class InputWizardDialogComponent {
   expectedCharsCount: number = 90;
   useMathFields: boolean = false;
 
+  /**
+   * Whether a numbering can be chosen, i.e. whether there is more than one answer field.
+   *
+   * Kept as a field rather than derived from `answerCount` in the template, because the count is
+   * only applied when the box is left while the control beside it has to follow at once: typing a
+   * 3 and reaching for the numbering has to find it enabled. A getter in the binding would do the
+   * same but re-run on every check (rules.md §1).
+   */
+  numberingAvailable: boolean = false;
+
   /** The last valid entry in the answer count box, applied when the field is left. */
   private pendingAnswerCount: number | null = null;
 
@@ -35,9 +45,11 @@ export class InputWizardDialogComponent {
   commitAnswerCount(update: { value: number | null; isInputValid: boolean }): void {
     if (!this.accept(update)) {
       this.pendingAnswerCount = null;
+      this.numberingAvailable = this.answerCount >= 2;
       return;
     }
     this.pendingAnswerCount = update.value as number;
+    this.numberingAvailable = this.pendingAnswerCount >= 2;
   }
 
   /**
@@ -55,6 +67,7 @@ export class InputWizardDialogComponent {
     if (this.pendingAnswerCount === null) return;
     this.answerCount = this.pendingAnswerCount;
     this.pendingAnswerCount = null;
+    this.numberingAvailable = this.answerCount >= 2;
     this.updateSubQuestions();
   }
 

--- a/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.html
+++ b/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.html
@@ -28,7 +28,9 @@
       <div class="fx-row-start-center dimensions-row">
         <mat-form-field appearance="fill" style="flex: 1;">
           <mat-label>{{ 'imageResizeDialog.maxWidth' | translate }}</mat-label>
-          <input matInput type="number" min="1" [(ngModel)]="data.options.maxWidth" (ngModelChange)="onWidthChange($event)">
+          <input matInput type="number" min="1" required aspectNumberField
+                 [ngModel]="data.options.maxWidth"
+                 (numberChange)="commitWidth($event)">
         </mat-form-field>
 
         <mat-icon class="aspect-ratio-lock" color="primary"
@@ -38,7 +40,9 @@
 
         <mat-form-field appearance="fill" style="flex: 1;">
           <mat-label>{{ 'imageResizeDialog.maxHeight' | translate }}</mat-label>
-          <input matInput type="number" min="1" [(ngModel)]="data.options.maxHeight" (ngModelChange)="onHeightChange($event)">
+          <input matInput type="number" min="1" required aspectNumberField
+                 [ngModel]="data.options.maxHeight"
+                 (numberChange)="commitHeight($event)">
         </mat-form-field>
       </div>
 

--- a/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.spec.ts
+++ b/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.spec.ts
@@ -13,7 +13,13 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ImageResizeDialogData } from 'common/models/image-interfaces';
 import { BytesPipe } from 'editor/src/app/pipes/bytes.pipe';
 import { SupportsQualityPipe } from 'editor/src/app/pipes/supports-quality.pipe';
-import { ImageResizeDialogComponent } from 'editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component';
+import {
+  ImageResizeDialogComponent
+} from 'editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 
 describe('ImageResizeDialogComponent', () => {
   let component: ImageResizeDialogComponent;
@@ -34,7 +40,9 @@ describe('ImageResizeDialogComponent', () => {
       declarations: [
         ImageResizeDialogComponent,
         BytesPipe,
-        SupportsQualityPipe
+        SupportsQualityPipe,
+        NumberFieldDirective,
+        NumberFieldBadInputDirective
       ],
       imports: [
         CommonModule,
@@ -127,5 +135,65 @@ describe('ImageResizeDialogComponent', () => {
     component.data.options.maxHeight = 75;
     component.onWidthChange(null as unknown as number);
     expect(component.data.options.maxHeight).toBe(75);
+  });
+
+  /* The two dimension boxes were bound two-way with an unenforced `min="1"`, so a 0, a negative
+     number or an emptied box went into the scaling options and on to `FileService.scaleImage`,
+     which is asked for an estimate on every keystroke (#1164). */
+  describe('the dimension boxes', () => {
+    const widthBox = (): HTMLInputElement => fixture.nativeElement
+      .querySelectorAll('input[type="number"]')[0] as HTMLInputElement;
+
+    /* `ngOnInit` loads the image and then clamps the width to it - and the fixture's image is a
+       single pixel. Waiting for that to happen before setting a starting point of our own is what
+       makes these deterministic; otherwise `img.onload` lands in the middle of a test and puts the
+       width back to 1. */
+    beforeEach(async () => {
+      await new Promise<void>(resolve => {
+        const waitForImage = (): void => {
+          if (component.originalWidth !== 0) resolve();
+          else setTimeout(waitForImage);
+        };
+        waitForImage();
+      });
+
+      component.originalWidth = 800;
+      component.originalHeight = 400;
+      component.data.options.maxWidth = 400;
+      component.data.options.maxHeight = 200;
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    const edit = async (box: HTMLInputElement, value: string): Promise<void> => {
+      box.value = value;
+      box.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should take an edited width and follow it with the height', async () => {
+      await edit(widthBox(), '300');
+
+      expect(component.data.options.maxWidth).toBe(300);
+      expect(component.data.options.maxHeight).toBe(150); // the aspect ratio is kept
+    });
+
+    it('should refuse a width below the minimum and put the box back', async () => {
+      await edit(widthBox(), '0');
+
+      expect(component.data.options.maxWidth).toBe(400);
+      expect(component.data.options.maxHeight).toBe(200); // and the other box is left alone
+      expect(widthBox().value).toBe('400');
+    });
+
+    it('should refuse an emptied width', async () => {
+      await edit(widthBox(), '');
+
+      expect(component.data.options.maxWidth).toBe(400);
+      expect(widthBox().value).toBe('400');
+    });
   });
 });

--- a/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.spec.ts
+++ b/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.spec.ts
@@ -149,9 +149,14 @@ describe('ImageResizeDialogComponent', () => {
        makes these deterministic; otherwise `img.onload` lands in the middle of a test and puts the
        width back to 1. */
     beforeEach(async () => {
-      await new Promise<void>(resolve => {
+      await new Promise<void>((resolve, reject) => {
+        // Bounded on purpose: without it a decoder that never fires would hang the whole block
+        // until the runner's timeout, which says nothing about what went wrong.
+        let attempts = 0;
         const waitForImage = (): void => {
+          attempts += 1;
           if (component.originalWidth !== 0) resolve();
+          else if (attempts > 100) reject(new Error('the fixture image never loaded'));
           else setTimeout(waitForImage);
         };
         waitForImage();

--- a/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.ts
@@ -1,8 +1,10 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
 import { FileService } from 'common/services/file.service';
 import { ImageResizeDialogData } from 'common/models/image-interfaces';
 import { IMAGE_COMPRESSION_QUALITY, IMAGE_MAX_WIDTH } from 'common/config';
+import { MessageService } from 'editor/src/app/services/message.service';
 
 @Component({
   selector: 'aspect-image-resize-dialog',
@@ -16,7 +18,9 @@ export class ImageResizeDialogComponent implements OnInit {
   originalSize: number = 0;
   estimatedSize: number = 0;
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: ImageResizeDialogData) {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ImageResizeDialogData,
+              private messageService: MessageService,
+              private translateService: TranslateService) {
     this.data.options.maxWidth = this.data.options.maxWidth || IMAGE_MAX_WIDTH;
     this.data.options.quality = this.data.options.quality || IMAGE_COMPRESSION_QUALITY;
   }
@@ -42,6 +46,35 @@ export class ImageResizeDialogComponent implements OnInit {
   async updateEstimatedSize(): Promise<void> {
     const res = await FileService.scaleImage(this.data.base64, this.data.options);
     this.estimatedSize = Math.round((res.length * 3) / 4);
+  }
+
+  /**
+   * What `aspectNumberField` worked out for one of the two dimension boxes.
+   *
+   * The `min="1"` on both was never enforced, and the binding was two-way, so a 0, a negative
+   * number or an emptied box went straight into the scaling options - and from there into
+   * `FileService.scaleImage`, which is asked for an estimated size on every keystroke (#1164).
+   *
+   * The other dimension follows from the aspect ratio, which is why the write is not a plain
+   * assignment: refusing one box has to leave both alone.
+   */
+  commitWidth(update: { value: number | null; isInputValid: boolean }): void {
+    if (!this.accept(update)) return;
+    this.data.options.maxWidth = update.value as number;
+    this.onWidthChange(update.value as number);
+  }
+
+  commitHeight(update: { value: number | null; isInputValid: boolean }): void {
+    if (!this.accept(update)) return;
+    this.data.options.maxHeight = update.value as number;
+    this.onHeightChange(update.value as number);
+  }
+
+  /** Both boxes are `required`, so a valid update carries a number; a refused one is said out loud. */
+  private accept(update: { value: number | null; isInputValid: boolean }): boolean {
+    if (update.isInputValid && update.value !== null) return true;
+    this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+    return false;
   }
 
   onWidthChange(value: number): void {

--- a/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/image-resize-dialog/image-resize-dialog.component.ts
@@ -52,8 +52,12 @@ export class ImageResizeDialogComponent implements OnInit {
    * What `aspectNumberField` worked out for one of the two dimension boxes.
    *
    * The `min="1"` on both was never enforced, and the binding was two-way, so a 0, a negative
-   * number or an emptied box went straight into the scaling options - and from there into
-   * `FileService.scaleImage`, which is asked for an estimated size on every keystroke (#1164).
+   * number or an emptied box went straight into the scaling options, and from there into
+   * `FileService.scaleImage` (#1164).
+   *
+   * The estimate is still recalculated per keystroke, and those calls are neither awaited nor
+   * sequenced - whichever scaling finishes last wins, so a fast typist can be left with the
+   * estimate for an earlier width. That was so before and is not touched here.
    *
    * The other dimension follows from the aspect ratio, which is why the write is not a plain
    * assignment: refusing one box has to leave both alone.

--- a/projects/editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component.html
+++ b/projects/editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component.html
@@ -20,10 +20,13 @@
       <input matInput
              type="number"
              step="1000"
+             min="0"
+             required
+             aspectNumberField
              [disabled]="enableReHide"
              [placeholder]="'section.visibilityDelay' | translate"
-             [(ngModel)]="visibilityDelay"
-             (change)="visibilityDelay = visibilityDelay || 0">
+             [ngModel]="visibilityDelay"
+             (numberChange)="commitDelay($event)">
     </mat-form-field>
   </div>
 

--- a/projects/editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component.spec.ts
+++ b/projects/editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component.spec.ts
@@ -18,6 +18,10 @@ import {
 import {
   VisibilityRulesDialogComponent
 } from 'editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 
 describe('VisibilityRulesDialogComponent', () => {
   let component: VisibilityRulesDialogComponent;
@@ -37,7 +41,8 @@ describe('VisibilityRulesDialogComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [
         VisibilityRulesDialogComponent,
-        VisibilityRuleEditorComponent
+        VisibilityRuleEditorComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective
       ],
       imports: [
         CommonModule,
@@ -159,6 +164,55 @@ describe('VisibilityRulesDialogComponent', () => {
 
       expect(dialogRefMock.close).toHaveBeenCalledTimes(1);
       expect(dialogRefMock.close.mock.lastCall?.[0]).toBeFalsy();
+    });
+  });
+
+  /* The delay box carried the old rule in its last hand-written form: a two-way binding plus
+     `(change)="visibilityDelay = visibilityDelay || 0"`, so an emptied box became a 0 and nothing
+     stopped a negative delay (#1164). */
+  describe('the delay box', () => {
+    beforeEach(async () => {
+      await configureTestBed({
+        visibilityRules: [{ id: 'checkbox_1', operator: '=', value: 'true' }],
+        logicalConnectiveOfRules: 'conjunction',
+        visibilityDelay: 1000,
+        animatedVisibility: true,
+        controlIds: [{ id: 'checkbox_1', alias: 'Kontrollkästchen' }],
+        enableReHide: false // the box is disabled while re-hiding is on
+      });
+      await fixture.whenStable();
+    });
+
+    const delayBox = (): HTMLInputElement => fixture.nativeElement
+      .querySelector('input[type="number"]') as HTMLInputElement;
+
+    const edit = async (value: string): Promise<void> => {
+      delayBox().value = value;
+      delayBox().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      delayBox().dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should take an edited delay', async () => {
+      await edit('2000');
+
+      expect(component.visibilityDelay).toBe(2000);
+    });
+
+    it('should refuse a negative delay and put the box back', async () => {
+      await edit('-1000');
+
+      expect(component.visibilityDelay).toBe(1000);
+      expect(delayBox().value).toBe('1000');
+    });
+
+    it('should refuse an emptied delay rather than make it zero', async () => {
+      await edit('');
+
+      expect(component.visibilityDelay).toBe(1000);
+      expect(delayBox().value).toBe('1000');
     });
   });
 });

--- a/projects/editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component.ts
+++ b/projects/editor/src/app/components/dialogs/visibility-rules-dialog/visibility-rules-dialog.component.ts
@@ -1,6 +1,8 @@
 import { Component, Inject } from '@angular/core';
-import { VisibilityRule } from 'common/models/visibility-rule';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
+import { VisibilityRule } from 'common/models/visibility-rule';
+import { MessageService } from 'editor/src/app/services/message.service';
 
 @Component({
   templateUrl: './visibility-rules-dialog.component.html',
@@ -23,7 +25,9 @@ export class VisibilityRulesDialogComponent {
       animatedVisibility: boolean,
       controlIds: { id: string, alias: string }[],
       enableReHide: boolean,
-    }
+    },
+    private messageService: MessageService,
+    private translateService: TranslateService
   ) {
     this.visibilityRules = [...data.visibilityRules];
     this.logicalConnectiveOfRules = data.logicalConnectiveOfRules;
@@ -31,6 +35,21 @@ export class VisibilityRulesDialogComponent {
     this.animatedVisibility = data.animatedVisibility;
     this.enableReHide = data.enableReHide;
     this.controlIds = data.controlIds;
+  }
+
+  /**
+   * What `aspectNumberField` worked out for the delay box.
+   *
+   * It carried the old rule in its last hand-written form - `(change)="visibilityDelay =
+   * visibilityDelay || 0"` on a two-way binding, so an emptied box became a 0 and nothing stopped a
+   * negative delay, which the player would treat as no delay at all (#1164).
+   */
+  commitDelay(update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      return;
+    }
+    this.visibilityDelay = update.value;
   }
 
   addVisibilityRule(): void {

--- a/projects/editor/src/app/components/page-menu/page-menu.component.html
+++ b/projects/editor/src/app/components/page-menu/page-menu.component.html
@@ -40,18 +40,18 @@
   </p>
   <mat-form-field class="menuItem" appearance="fill">
     <mat-label>Seitenbreite in px</mat-label>
-    <input matInput type="number" min="0" #maxWidth="ngModel"
+    <input matInput type="number" min="0" required aspectNumberField
            [disabled]="!page.hasMaxWidth"
            [ngModel]="page.hasMaxWidth ? page.maxWidth : null"
            (click)="$event.stopPropagation()"
-           (ngModelChange)="updateModel(page,'maxWidth', $event || 0, maxWidth.valid)">
+           (numberChange)="commitNumber(page, 'maxWidth', $event)">
   </mat-form-field>
   <mat-form-field class="menuItem" appearance="fill">
     <mat-label>Randbreite in px</mat-label>
-    <input matInput type="number" min="0" #margin="ngModel"
+    <input matInput type="number" min="0" required aspectNumberField
            [ngModel]="page.margin"
            (click)="$event.stopPropagation()"
-           (ngModelChange)="updateModel(page,'margin', $event || 0, margin.valid)">
+           (numberChange)="commitNumber(page, 'margin', $event)">
   </mat-form-field>
 </fieldset>
 
@@ -82,9 +82,9 @@
 </mat-form-field>
 <mat-form-field *ngIf="unitService.expertMode" class="menuItem" appearance="fill">
   <mat-label>{{'pageProperties.alwaysVisibleAspectRatio' | translate }}</mat-label>
-  <input matInput type="number" min="0" max="100"
+  <input matInput type="number" min="0" max="100" required aspectNumberField
          [disabled]="!page.alwaysVisible"
          [ngModel]="page.alwaysVisibleAspectRatio"
          (click)="$event.stopPropagation()"
-         (ngModelChange)="updateModel(page, 'alwaysVisibleAspectRatio', $event || 0)">
+         (numberChange)="commitNumber(page, 'alwaysVisibleAspectRatio', $event)">
 </mat-form-field>

--- a/projects/editor/src/app/components/page-menu/page-menu.component.spec.ts
+++ b/projects/editor/src/app/components/page-menu/page-menu.component.spec.ts
@@ -18,6 +18,10 @@ import { MessageService } from 'editor/src/app/services/message.service';
 import { PageService } from 'editor/src/app/services/page.service';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import { UnitService } from 'editor/src/app/services/unit.service';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 
 describe('PageMenu', () => {
   let component: PageMenu;
@@ -47,7 +51,7 @@ describe('PageMenu', () => {
     } as unknown as UnitService;
 
     await TestBed.configureTestingModule({
-      declarations: [PageMenu],
+      declarations: [PageMenu, NumberFieldDirective, NumberFieldBadInputDirective],
       imports: [
         CommonModule,
         FormsModule,
@@ -107,11 +111,13 @@ describe('PageMenu', () => {
     expect(messageService.showWarning).not.toHaveBeenCalled();
   });
 
+  /* The message goes through TranslateService now; with no translations loaded it yields the key.
+     It used to be a German literal in the component (rules.md §5). */
   it('should warn instead of writing an invalid value', () => {
     component.updateModel(component.page, 'maxWidth', 900, false);
 
     expect(component.page.maxWidth).toBe(750);
-    expect(messageService.showWarning).toHaveBeenCalledWith('Eingabe ungültig');
+    expect(messageService.showWarning).toHaveBeenCalledWith('inputInvalid');
     expect(updateUnitDefinition).not.toHaveBeenCalled();
   });
 
@@ -133,5 +139,70 @@ describe('PageMenu', () => {
     expect(updateSectionCounter).toHaveBeenCalled();
     expect(orderChanged).toBe(true);
     expect(alwaysVisibleModified).toBe(true);
+  });
+
+  /* The three number boxes had a guard already, and it was the closest of the pre-#1161 fields to
+     the right shape - but it hung on `(ngModelChange)`, so it judged every keystroke, and
+     `$event || 0` wrote a 0 for the one that emptied the box (#1164). */
+  describe('the number boxes', () => {
+    /* In template order: page width, margin, and - only in expert mode - the aspect ratio. */
+    const boxes = (): HTMLInputElement[] => Array.from(
+      fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>
+    );
+
+    const type = (box: HTMLInputElement, value: string): void => {
+      box.value = value;
+      box.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+    };
+    const leave = async (box: HTMLInputElement): Promise<void> => {
+      box.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should write an edited page width', async () => {
+      type(boxes()[0], '900');
+      await leave(boxes()[0]);
+
+      expect(component.page.maxWidth).toBe(900);
+      expect(messageService.showWarning).not.toHaveBeenCalled();
+    });
+
+    /* One warning for the whole edit: typing `-50` passes through `-5`, and judging the keystroke
+       put one warning on screen after the other. */
+    it('should warn once for an edit that passes through several invalid values', async () => {
+      type(boxes()[0], '-5');
+      type(boxes()[0], '-50');
+      expect(messageService.showWarning).not.toHaveBeenCalled();
+
+      await leave(boxes()[0]);
+
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+      expect(component.page.maxWidth).toBe(750);
+      expect(boxes()[0].value).toBe('750');
+    });
+
+    it('should refuse an emptied width rather than write a zero', async () => {
+      type(boxes()[0], '');
+      await leave(boxes()[0]);
+
+      expect(component.page.maxWidth).toBe(750);
+      expect(boxes()[0].value).toBe('750');
+    });
+
+    /* The aspect ratio passed no validity at all, so its `min="0" max="100"` meant nothing. */
+    it('should refuse an aspect ratio above the maximum', async () => {
+      component.page.alwaysVisible = true;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const ratio = boxes()[2];
+
+      type(ratio, '150');
+      await leave(ratio);
+
+      expect(component.page.alwaysVisibleAspectRatio).toBe(50);
+      expect(ratio.value).toBe('50');
+    });
   });
 });

--- a/projects/editor/src/app/components/page-menu/page-menu.component.spec.ts
+++ b/projects/editor/src/app/components/page-menu/page-menu.component.spec.ts
@@ -191,6 +191,24 @@ describe('PageMenu', () => {
       expect(boxes()[0].value).toBe('750');
     });
 
+    /* The margin box had the same guard and the same hole, and nothing pinned either. */
+    it('should refuse an emptied margin', async () => {
+      type(boxes()[1], '');
+      await leave(boxes()[1]);
+
+      expect(component.page.margin).toBe(30);
+      expect(boxes()[1].value).toBe('30');
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refuse a negative margin', async () => {
+      type(boxes()[1], '-10');
+      await leave(boxes()[1]);
+
+      expect(component.page.margin).toBe(30);
+      expect(boxes()[1].value).toBe('30');
+    });
+
     /* The aspect ratio passed no validity at all, so its `min="0" max="100"` meant nothing. */
     it('should refuse an aspect ratio above the maximum', async () => {
       component.page.alwaysVisible = true;

--- a/projects/editor/src/app/components/page-menu/page-menu.component.ts
+++ b/projects/editor/src/app/components/page-menu/page-menu.component.ts
@@ -1,6 +1,7 @@
 import {
   Component, EventEmitter, Input, OnDestroy, Output
 } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import { UnitService } from 'editor/src/app/services/unit.service';
 import { MessageService } from 'editor/src/app/services/message.service';
@@ -24,7 +25,8 @@ export class PageMenu implements OnDestroy {
   constructor(public unitService: UnitService,
               public pageService: PageService,
               public selectionService: SelectionService,
-              private messageService: MessageService) {}
+              private messageService: MessageService,
+              private translateService: TranslateService) {}
 
   movePage(direction: 'left' | 'right'): void {
     this.pageService.moveSelectedPage(this.selectionService.selectedPageIndex, direction);
@@ -50,8 +52,27 @@ export class PageMenu implements OnDestroy {
       page[property] = value;
       this.unitService.updateUnitDefinition(); // TODO
     } else {
-      this.messageService.showWarning('Eingabe ungültig');
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
     }
+  }
+
+  /**
+   * What `aspectNumberField` worked out for one of the three number boxes.
+   *
+   * They had a guard already, and it was the closest of all the pre-#1161 fields to the right
+   * shape - but it hung on `(ngModelChange)`, so it judged every keystroke: typing `-50` warned
+   * twice on its way through `-5`, and `$event || 0` wrote a 0 for the keystroke that emptied the
+   * box. The aspect ratio passed no validity at all, so its `min="0" max="100"` meant nothing
+   * (#1164).
+   */
+  commitNumber(page: EditorPage,
+               property: 'maxWidth' | 'margin' | 'alwaysVisibleAspectRatio',
+               update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      return;
+    }
+    this.updateModel(page, property, update.value);
   }
 
   private movePageToFront(page: EditorPage): void {

--- a/projects/editor/src/app/components/page-menu/page-menu.component.ts
+++ b/projects/editor/src/app/components/page-menu/page-menu.component.ts
@@ -68,6 +68,8 @@ export class PageMenu implements OnDestroy {
   commitNumber(page: EditorPage,
                property: 'maxWidth' | 'margin' | 'alwaysVisibleAspectRatio',
                update: { value: number | null; isInputValid: boolean }): void {
+    // The box is `required`, so a valid update always carries a number - the null check is
+    // what narrows the type, not a case that can occur.
     if (!update.isInputValid || update.value === null) {
       this.messageService.showWarning(this.translateService.instant('inputInvalid'));
       return;

--- a/projects/editor/src/app/components/section-menu/section-menu.component.html
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.html
@@ -100,6 +100,7 @@
                                      [value]="size.value"
                                      [unit]="size.unit"
                                      [allowedUnits]="['px', 'fr']"
+                                     [min]="0"
                                      (valueUpdated)="changeGridSize('gridRowSizes', i, $event)">
             </aspect-size-input-panel>
           </ng-container>
@@ -126,6 +127,7 @@
                                      [value]="size.value"
                                      [unit]="size.unit"
                                      [allowedUnits]="['px', 'fr']"
+                                     [min]="0"
                                      (valueUpdated)="changeGridSize('gridColumnSizes', i, $event)">
             </aspect-size-input-panel>
           </ng-container>

--- a/projects/editor/src/app/components/section-menu/section-menu.component.html
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.html
@@ -93,7 +93,8 @@
                    [ngModel]="section.gridRowSizes.length"
                    (click)="$any($event).stopPropagation()"
                    (numberChange)="commitCount('gridRowSizes', $event)"
-                   (blur)="applyCount('gridRowSizes')">
+                   (blur)="applyCount('gridRowSizes')"
+                   (keydown.enter)="applyCount('gridRowSizes')">
           </mat-form-field>
           <ng-container *ngFor="let size of section.gridRowSizes ; let i = index">
             <aspect-size-input-panel [label]="('section-menu.height' | translate) + ' ' + (i + 1)"
@@ -120,7 +121,8 @@
                    [ngModel]="section.gridColumnSizes.length"
                    (click)="$any($event).stopPropagation()"
                    (numberChange)="commitCount('gridColumnSizes', $event)"
-                   (blur)="applyCount('gridColumnSizes')">
+                   (blur)="applyCount('gridColumnSizes')"
+                   (keydown.enter)="applyCount('gridColumnSizes')">
           </mat-form-field>
           <ng-container *ngFor="let size of section.gridColumnSizes; let i = index">
             <aspect-size-input-panel [label]="('section-menu.width' | translate) + ' ' + (i + 1)"

--- a/projects/editor/src/app/components/section-menu/section-menu.component.html
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.html
@@ -92,7 +92,8 @@
             <input matInput type="number" min="1" required aspectNumberField
                    [ngModel]="section.gridRowSizes.length"
                    (click)="$any($event).stopPropagation()"
-                   (numberChange)="commitCount('gridRowSizes', $event)">
+                   (numberChange)="commitCount('gridRowSizes', $event)"
+                   (blur)="applyCount('gridRowSizes')">
           </mat-form-field>
           <ng-container *ngFor="let size of section.gridRowSizes ; let i = index">
             <aspect-size-input-panel [label]="('section-menu.height' | translate) + ' ' + (i + 1)"
@@ -117,7 +118,8 @@
             <input matInput type="number" min="1" required aspectNumberField
                    [ngModel]="section.gridColumnSizes.length"
                    (click)="$any($event).stopPropagation()"
-                   (numberChange)="commitCount('gridColumnSizes', $event)">
+                   (numberChange)="commitCount('gridColumnSizes', $event)"
+                   (blur)="applyCount('gridColumnSizes')">
           </mat-form-field>
           <ng-container *ngFor="let size of section.gridColumnSizes; let i = index">
             <aspect-size-input-panel [label]="('section-menu.width' | translate) + ' ' + (i + 1)"

--- a/projects/editor/src/app/components/section-menu/section-menu.component.html
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.html
@@ -64,10 +64,10 @@
     <ng-container *ngIf="!section.dynamicPositioning">
       <mat-form-field class="section-height-input" appearance="outline">
         <mat-label>{{'section-menu.height' | translate }}</mat-label>
-        <input matInput type="number"
-               [value]="$any(section.height)"
+        <input matInput type="number" min="0" required aspectNumberField
+               [ngModel]="section.height"
                (click)="$any($event).stopPropagation()"
-               (change)="updateModel('height', $any($event.target).value || 0)">
+               (numberChange)="commitHeight($event)">
       </mat-form-field>
     </ng-container>
     <div *ngIf="section.dynamicPositioning">
@@ -81,18 +81,18 @@
         <ng-container *ngIf="!section.autoRowSize">
           <mat-form-field appearance="outline">
             <mat-label>{{'section-menu.height' | translate }}</mat-label>
-            <input matInput type="number"
-                   [value]="$any(section.height)"
+            <input matInput type="number" min="0" required aspectNumberField
+                   [ngModel]="section.height"
                    (click)="$any($event).stopPropagation()"
-                   (change)="updateModel('height', $any($event.target).value || 0)">
+                   (numberChange)="commitHeight($event)">
           </mat-form-field>
 
           <mat-form-field appearance="outline">
             <mat-label>{{'section-menu.rowCount' | translate }}</mat-label>
-            <input matInput type="number"
-                   [value]="$any(section.gridRowSizes.length)"
+            <input matInput type="number" min="1" required aspectNumberField
+                   [ngModel]="section.gridRowSizes.length"
                    (click)="$any($event).stopPropagation()"
-                   (change)="modifySizeArray('gridRowSizes', $any($event).target.value || 0)">
+                   (numberChange)="commitCount('gridRowSizes', $event)">
           </mat-form-field>
           <ng-container *ngFor="let size of section.gridRowSizes ; let i = index">
             <aspect-size-input-panel [label]="('section-menu.height' | translate) + ' ' + (i + 1)"
@@ -114,10 +114,10 @@
         <ng-container *ngIf="!section.autoColumnSize">
           <mat-form-field appearance="outline">
             <mat-label>{{'section-menu.columnCount' | translate }}</mat-label>
-            <input matInput type="number"
-                   [value]="$any(section.gridColumnSizes.length)"
+            <input matInput type="number" min="1" required aspectNumberField
+                   [ngModel]="section.gridColumnSizes.length"
                    (click)="$any($event).stopPropagation()"
-                   (change)="modifySizeArray('gridColumnSizes', $any($event).target.value || 0)">
+                   (numberChange)="commitCount('gridColumnSizes', $event)">
           </mat-form-field>
           <ng-container *ngFor="let size of section.gridColumnSizes; let i = index">
             <aspect-size-input-panel [label]="('section-menu.width' | translate) + ' ' + (i + 1)"

--- a/projects/editor/src/app/components/section-menu/section-menu.component.spec.ts
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.spec.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -17,6 +18,10 @@ import { of } from 'rxjs';
 import { UIElement } from 'common/models/elements/element';
 import { Measurement } from 'common/models/ui-element-interfaces';
 import { createSpyObj, SpyObj } from 'common/utils/vitest-spy-object';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import { SectionMenuComponent } from 'editor/src/app/components/section-menu/section-menu.component';
 import { EditorPage } from 'editor/src/app/models/editor-page';
 import { EditorSection } from 'editor/src/app/models/editor-section';
@@ -57,7 +62,7 @@ describe('SectionMenuComponent', () => {
       'duplicateSection', 'insertSection', 'replaceSection'
     ]);
     dialogService = createSpyObj<DialogService>(['showSectionInsertDialog', 'showVisibilityRulesDialog']);
-    messageService = createSpyObj<MessageService>(['showSuccess']);
+    messageService = createSpyObj<MessageService>(['showSuccess', 'showWarning']);
     clipboard = createSpyObj<Clipboard>(['copy']);
     selectionService = new SelectionService();
     unitServiceMock = {
@@ -71,9 +76,13 @@ describe('SectionMenuComponent', () => {
     } as unknown as UnitService;
 
     await TestBed.configureTestingModule({
-      declarations: [SectionMenuComponent, MockSizeInputPanelComponent],
+      declarations: [
+        SectionMenuComponent, MockSizeInputPanelComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective
+      ],
       imports: [
         CommonModule,
+        FormsModule,
         MatButtonModule,
         MatCheckboxModule,
         MatFormFieldModule,
@@ -145,6 +154,86 @@ describe('SectionMenuComponent', () => {
 
     expect(sectionService.updateSectionProperty)
       .toHaveBeenCalledWith(component.section, 'gridRowSizes', [{ value: 2, unit: 'px' }]);
+  });
+
+  /* The four number boxes live in the layout menu, so these open it and go through the boxes: what
+     was wrong was the wiring, not the array logic above. They passed `$event.target.value` on - a
+     string into `height`, which is declared `number` - and `|| 0` turned an emptied box into a 0,
+     which for the counts cut the size array to nothing (#1164). */
+  describe('the layout number boxes', () => {
+    /* The menu renders into an overlay, outside the fixture. In template order: section height,
+       then the row count, then the column count - the second height box belongs to the other
+       branch of `dynamicPositioning` and is not rendered at the same time. */
+    const boxes = (): HTMLInputElement[] => Array.from(
+      document.querySelectorAll('.layoutMenu input[type="number"]') as NodeListOf<HTMLInputElement>
+    );
+
+    const edit = async (box: HTMLInputElement, value: string): Promise<void> => {
+      box.value = value;
+      box.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    beforeEach(async () => {
+      component.section.dynamicPositioning = true;
+      component.section.autoRowSize = false;
+      component.section.autoColumnSize = false;
+      component.section.height = 400;
+      component.section.gridRowSizes = [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }];
+      component.section.gridColumnSizes = [{ value: 1, unit: 'fr' }];
+      fixture.detectChanges();
+      // The second of the two menus in this component: the element list is the first.
+      const layoutMenuButton = Array.from(
+        fixture.nativeElement.querySelectorAll('[aria-haspopup="menu"]') as NodeListOf<HTMLButtonElement>
+      )[1];
+      layoutMenuButton.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('should write an edited height as a number', async () => {
+      await edit(boxes()[0], '300');
+
+      expect(sectionService.updateSectionProperty)
+        .toHaveBeenCalledWith(component.section, 'height', 300);
+    });
+
+    it('should refuse an emptied height', async () => {
+      await edit(boxes()[0], '');
+
+      expect(sectionService.updateSectionProperty).not.toHaveBeenCalled();
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+      expect(boxes()[0].value).toBe('400');
+    });
+
+    /* The one that lost data: an emptied count wrote 0, and the whole size array went with it. */
+    it('should refuse an emptied row count rather than drop every row', async () => {
+      await edit(boxes()[1], '');
+
+      expect(sectionService.updateSectionProperty).not.toHaveBeenCalled();
+      expect(messageService.showWarning).toHaveBeenCalledTimes(1);
+      expect(boxes()[1].value).toBe('2');
+    });
+
+    /* And a typed 0, which the box took before and which leaves a grid with no tracks at all. */
+    it('should refuse a row count of zero', async () => {
+      await edit(boxes()[1], '0');
+
+      expect(sectionService.updateSectionProperty).not.toHaveBeenCalled();
+      expect(boxes()[1].value).toBe('2');
+    });
+
+    it('should take a valid row count', async () => {
+      await edit(boxes()[1], '3');
+
+      expect(sectionService.updateSectionProperty).toHaveBeenCalledWith(
+        component.section, 'gridRowSizes',
+        [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }]
+      );
+    });
   });
 
   it('should replace a single grid size', () => {

--- a/projects/editor/src/app/components/section-menu/section-menu.component.spec.ts
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.spec.ts
@@ -34,6 +34,7 @@ import { UnitService } from 'editor/src/app/services/unit.service';
 
 @Component({ selector: 'aspect-size-input-panel', standalone: false, template: '' })
 class MockSizeInputPanelComponent {
+  @Input() min: number | null = null;
   @Input() label!: string;
   @Input() value!: number;
   @Input() unit!: string;

--- a/projects/editor/src/app/components/section-menu/section-menu.component.spec.ts
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.spec.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
+import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { MatButtonModule } from '@angular/material/button';
@@ -225,6 +226,17 @@ describe('SectionMenuComponent', () => {
 
       expect(sectionService.updateSectionProperty).not.toHaveBeenCalled();
       expect(boxes()[1].value).toBe('2');
+    });
+
+    /* The shared panel takes its floor from the call site: a grid track shorter than nothing is not
+       a length, while the margins that use the same panel do want negative values (#1164). */
+    it('should give the track size panels a floor of zero', () => {
+      const panels = fixture.debugElement.queryAll(By.directive(MockSizeInputPanelComponent));
+
+      expect(panels.length).toBeGreaterThan(0);
+      panels.forEach(panel => {
+        expect((panel.componentInstance as MockSizeInputPanelComponent).min).toBe(0);
+      });
     });
 
     it('should take a valid row count', async () => {

--- a/projects/editor/src/app/components/section-menu/section-menu.component.ts
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.ts
@@ -4,6 +4,7 @@ import {
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { TranslateService } from '@ngx-translate/core';
 import { CompoundElement, UIElement } from 'common/models/elements/element';
 import { VisibilityRule } from 'common/models/visibility-rule';
 import { MessageService } from 'editor/src/app/services/message.service';
@@ -40,6 +41,7 @@ export class SectionMenuComponent implements OnDestroy {
               private dialogService: DialogService,
               private messageService: MessageService,
               private idService: IDService,
+              private translateService: TranslateService,
               private clipboard: Clipboard) { }
 
   updateModel(
@@ -69,6 +71,39 @@ export class SectionMenuComponent implements OnDestroy {
 
   deleteSection(): void {
     this.sectionService.deleteSection(this.selectionService.selectedPageIndex, this.sectionIndex);
+  }
+
+  /**
+   * What `aspectNumberField` worked out for the section height.
+   *
+   * The four number boxes in this menu passed `$event.target.value` straight on - a string, into
+   * `height`, which is declared `number` - and `|| 0` turned an emptied box into a 0, which
+   * collapses the section. Neither `min` nor anything else was enforced anywhere (#1164).
+   */
+  commitHeight(update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      return;
+    }
+    this.updateModel('height', update.value);
+  }
+
+  /**
+   * The same for the two grid track counts, where an emptied box did more than write a wrong
+   * number: `|| 0` cut the size array to nothing, so a section lost every row or column definition
+   * at once. `min="1"` because a grid with no tracks is not a grid.
+   *
+   * Unlike the table, this has no floor tied to the elements inside it - shrinking the grid past an
+   * element leaves that element with a track that no longer exists. That was so before and is left
+   * alone here; #1164 is about the boxes.
+   */
+  commitCount(property: 'gridColumnSizes' | 'gridRowSizes',
+              update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
+      this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      return;
+    }
+    this.modifySizeArray(property, update.value);
   }
 
   /* Add or remove elements to size array. Default value 1fr. */

--- a/projects/editor/src/app/components/section-menu/section-menu.component.ts
+++ b/projects/editor/src/app/components/section-menu/section-menu.component.ts
@@ -35,6 +35,9 @@ export class SectionMenuComponent implements OnDestroy {
 
   sectionElements: UIElement[] = [];
 
+  /** The last valid entry per count box, applied when that field is left. */
+  private pendingCount: Partial<Record<'gridColumnSizes' | 'gridRowSizes', number>> = {};
+
   constructor(public unitService: UnitService,
               private sectionService: SectionService,
               private selectionService: SelectionService,
@@ -101,9 +104,28 @@ export class SectionMenuComponent implements OnDestroy {
               update: { value: number | null; isInputValid: boolean }): void {
     if (!update.isInputValid || update.value === null) {
       this.messageService.showWarning(this.translateService.instant('inputInvalid'));
+      delete this.pendingCount[property];
       return;
     }
-    this.modifySizeArray(property, update.value);
+    this.pendingCount[property] = update.value;
+  }
+
+  /**
+   * The count is applied on leaving the field, not on the keystroke.
+   *
+   * Every two-digit entry passes through a single digit first, and applying that digit cuts the
+   * size array down to it - so typing 12 over a 2 dropped the second row's height and came back
+   * with ten default tracks instead. The original handler was on `(change)`, i.e. here; the
+   * migration is what moved it to the keystroke (#1164).
+   *
+   * The directive's own blur listener runs first (measured), so a refused entry has already cleared
+   * what was pending by the time this asks.
+   */
+  applyCount(property: 'gridColumnSizes' | 'gridRowSizes'): void {
+    const pending = this.pendingCount[property];
+    if (pending === undefined) return;
+    delete this.pendingCount[property];
+    this.modifySizeArray(property, pending);
   }
 
   /* Add or remove elements to size array. Default value 1fr. */

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.html
@@ -2,7 +2,9 @@
   <mat-form-field class="wide-form-field" matTooltip="{{'propertiesPanel.firstColumnSizeRatioExplanation' | translate }}"
                   appearance="fill">
     <mat-label>{{'propertiesPanel.firstColumnSizeRatio' | translate }}</mat-label>
-    <input #firstColumnSizeRatioField matInput type="number" [value]="combinedProperties.firstColumnSizeRatio"
-           (input)="updateModel.emit({ property: 'firstColumnSizeRatio', value: firstColumnSizeRatioField.value || 0 })">
+    <input matInput type="number" required aspectNumberField
+           [ngModel]="combinedProperties.firstColumnSizeRatio"
+           (numberChange)="updateModel.emit(
+                  { property: 'firstColumnSizeRatio', value: $event.value, isInputValid: $event.isInputValid })">
   </mat-form-field>
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.html
@@ -2,7 +2,7 @@
   <mat-form-field class="wide-form-field" matTooltip="{{'propertiesPanel.firstColumnSizeRatioExplanation' | translate }}"
                   appearance="fill">
     <mat-label>{{'propertiesPanel.firstColumnSizeRatio' | translate }}</mat-label>
-    <input matInput type="number" required aspectNumberField
+    <input matInput type="number" min="1" required aspectNumberField
            [ngModel]="combinedProperties.firstColumnSizeRatio"
            (numberChange)="updateModel.emit(
                   { property: 'firstColumnSizeRatio', value: $event.value, isInputValid: $event.isInputValid })">

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.spec.ts
@@ -1,9 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import {
   FirstColumnRatioPropertiesComponent
 } from './first-column-ratio-properties.component';
@@ -14,8 +19,11 @@ describe('FirstColumnRatioPropertiesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [FirstColumnRatioPropertiesComponent],
+      declarations: [
+        FirstColumnRatioPropertiesComponent, NumberFieldDirective, NumberFieldBadInputDirective
+      ],
       imports: [
+        FormsModule,
         MatFormFieldModule,
         MatInputModule,
         MatTooltipModule,
@@ -37,15 +45,38 @@ describe('FirstColumnRatioPropertiesComponent', () => {
     expect(fixture.debugElement.query(By.css('input')).nativeElement.value).toBe('3');
   });
 
-  it('should emit the entered ratio', () => {
-    const emitted: { property: string; value: number | string }[] = [];
+  /* `firstColumnSizeRatio` is declared `number`, and the box used to hand on `field.value` - the
+     raw string - so the unit definition ended up with "5" where a 5 belongs (#1164). */
+  it('should emit the entered ratio as a number', () => {
+    const emitted: { property: string; value: unknown; isInputValid?: boolean | null }[] = [];
     component.updateModel.subscribe(update => emitted.push(update));
 
     const input = fixture.debugElement.query(By.css('input'));
     input.nativeElement.value = '5';
-    input.triggerEventHandler('input', { target: input.nativeElement });
+    input.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
 
-    expect(emitted).toEqual([{ property: 'firstColumnSizeRatio', value: '5' }]);
+    expect(emitted).toEqual([{ property: 'firstColumnSizeRatio', value: 5, isInputValid: true }]);
+  });
+
+  /* And `|| 0` turned every keystroke that left the box unreadable into a 0 - the first press of
+     a minus sign, or clearing it to retype. It is refused on leaving now, and the box goes back. */
+  it('should refuse an emptied ratio and put the box back', async () => {
+    const emitted: { property: string; value: unknown; isInputValid?: boolean | null }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    const input = fixture.debugElement.query(By.css('input'));
+    input.nativeElement.value = '';
+    input.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(emitted).toEqual([]);
+
+    input.nativeElement.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual([{ property: 'firstColumnSizeRatio', value: null, isInputValid: false }]);
+    expect(input.nativeElement.value).toBe('3');
   });
 
   // The panel offers the control only for elements that have the property at all.

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.spec.ts
@@ -94,4 +94,22 @@ describe('FirstColumnRatioPropertiesComponent', () => {
 
     expect(fixture.debugElement.query(By.css('mat-form-field'))).toBeNull();
   });
+
+  /* The ratio ends up in `grid-template-columns: Nfr 1fr`, so a 0 collapses the label column and a
+     negative one is not a length at all. Nothing enforced that before (#1164). */
+  it('should refuse a ratio below one', async () => {
+    const emitted: { property: string; value: unknown; isInputValid?: boolean | null }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    const input = fixture.debugElement.query(By.css('input'));
+    input.nativeElement.value = '0';
+    input.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    input.nativeElement.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual([{ property: 'firstColumnSizeRatio', value: 0, isInputValid: false }]);
+    expect(input.nativeElement.value).toBe('3');
+  });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.ts
@@ -19,14 +19,14 @@ import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-pr
 export class FirstColumnRatioPropertiesComponent {
   @Input() combinedProperties!: Merged<FirstColumnRatioProperties>;
   /**
-   * `value` is a string for anything the author types: `input[type=number].value` is a string, and
-   * the panel has always passed it on unconverted, so the model ends up holding `'5'` rather than
-   * `5`. Typed as it actually behaves; normalising it would be a change of behaviour, not of types.
+   * A number now. The box used to pass `input.value` on unconverted, so the model ended up holding
+   * `'5'` rather than `5` - that is what #1164 changed here. `null` is what a refused entry carries;
+   * the caller acts on `isInputValid` rather than on the value.
    */
   @Output() updateModel =
     new EventEmitter<{
       property: keyof FirstColumnRatioProperties;
-      value: number | string | null;
+      value: number | null;
       isInputValid?: boolean | null
     }>();
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/first-column-ratio-properties/first-column-ratio-properties.component.ts
@@ -24,5 +24,9 @@ export class FirstColumnRatioPropertiesComponent {
    * `5`. Typed as it actually behaves; normalising it would be a change of behaviour, not of types.
    */
   @Output() updateModel =
-    new EventEmitter<{ property: keyof FirstColumnRatioProperties; value: number | string }>();
+    new EventEmitter<{
+      property: keyof FirstColumnRatioProperties;
+      value: number | string | null;
+      isInputValid?: boolean | null
+    }>();
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.html
@@ -25,7 +25,7 @@
      (combinedProperties.rowCount != null && combinedProperties.hasDynamicRowCount === undefined)) {
   <mat-form-field class="wide-form-field" appearance="fill">
     <mat-label>{{'rows' | translate }}</mat-label>
-    <input matInput type="number" required aspectNumberField
+    <input matInput type="number" min="1" required aspectNumberField
            [ngModel]="combinedProperties.rowCount"
            (numberChange)="updateModel.emit(
                   { property: 'rowCount', value: $event.value, isInputValid: $event.isInputValid })">
@@ -35,7 +35,7 @@
 @if (combinedProperties.expectedCharactersCount != null && combinedProperties.hasDynamicRowCount) {
   <mat-form-field class="wide-form-field" appearance="fill">
     <mat-label>{{'propertiesPanel.expectedCharactersCount' | translate }}</mat-label>
-    <input matInput type="number" required aspectNumberField
+    <input matInput type="number" min="1" required aspectNumberField
            [disabled]="!!combinedProperties.hasAutoHeight"
            [ngModel]="combinedProperties.expectedCharactersCount"
            (numberChange)="updateModel.emit(

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.html
@@ -25,18 +25,20 @@
      (combinedProperties.rowCount != null && combinedProperties.hasDynamicRowCount === undefined)) {
   <mat-form-field class="wide-form-field" appearance="fill">
     <mat-label>{{'rows' | translate }}</mat-label>
-    <input #rowCountField matInput type="number" [value]="combinedProperties.rowCount"
-           (input)="updateModel.emit({ property: 'rowCount', value: rowCountField.value || 0 })">
+    <input matInput type="number" required aspectNumberField
+           [ngModel]="combinedProperties.rowCount"
+           (numberChange)="updateModel.emit(
+                  { property: 'rowCount', value: $event.value, isInputValid: $event.isInputValid })">
   </mat-form-field>
 }
 
 @if (combinedProperties.expectedCharactersCount != null && combinedProperties.hasDynamicRowCount) {
   <mat-form-field class="wide-form-field" appearance="fill">
     <mat-label>{{'propertiesPanel.expectedCharactersCount' | translate }}</mat-label>
-    <input #expectedCharactersCountField matInput type="number"
+    <input matInput type="number" required aspectNumberField
            [disabled]="!!combinedProperties.hasAutoHeight"
-           [value]="combinedProperties.expectedCharactersCount"
-           (input)="updateModel.emit({
-             property: 'expectedCharactersCount', value: expectedCharactersCountField.value || 0 })">
+           [ngModel]="combinedProperties.expectedCharactersCount"
+           (numberChange)="updateModel.emit(
+                  { property: 'expectedCharactersCount', value: $event.value, isInputValid: $event.isInputValid })">
   </mat-form-field>
 }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.spec.ts
@@ -1,10 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { Component, DebugElement, Input } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { TranslateModule } from '@ngx-translate/core';
 import { UnitService } from 'editor/src/app/services/unit.service';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import {
   MultiLineTextPropertiesComponent
 } from './multi-line-text-properties.component';
@@ -38,8 +43,11 @@ describe('MultiLineTextPropertiesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MultiLineTextPropertiesComponent, MockMergedCheckboxComponent],
-      imports: [MatFormFieldModule, MatInputModule, TranslateModule.forRoot()],
+      declarations: [
+        MultiLineTextPropertiesComponent, MockMergedCheckboxComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective
+      ],
+      imports: [FormsModule, MatFormFieldModule, MatInputModule, TranslateModule.forRoot()],
       providers: [{ provide: UnitService, useValue: unitServiceMock }]
     }).compileComponents();
 
@@ -61,25 +69,48 @@ describe('MultiLineTextPropertiesComponent', () => {
     expect(inputs()[0].nativeElement.value).toBe('3');
   });
 
-  it('should swap the row count for the expected characters on a dynamic row count', () => {
+  it('should swap the row count for the expected characters on a dynamic row count', async () => {
     component.combinedProperties = {
       rowCount: 3, hasAutoHeight: false, hasDynamicRowCount: true, expectedCharactersCount: 100
     };
     fixture.detectChanges();
+    await fixture.whenStable(); // NgModel writes the box in a microtask
 
     expect(inputs().length).toBe(1);
     expect(inputs()[0].nativeElement.value).toBe('100');
   });
 
-  it('should emit the entered row count', () => {
-    const emitted: { property: string; value: unknown }[] = [];
+  /* `rowCount` is declared `number`, and the box handed on `field.value` - the raw string. On top
+     of that `|| 0` made every unreadable keystroke a 0, so clearing the box to retype wrote a 0
+     first (#1164). */
+  it('should emit the entered row count as a number', () => {
+    const emitted: { property: string; value: unknown; isInputValid?: boolean | null }[] = [];
     component.updateModel.subscribe(update => emitted.push(update));
 
     const input = inputs()[0];
     input.nativeElement.value = '7';
-    input.triggerEventHandler('input', { target: input.nativeElement });
+    input.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
 
-    expect(emitted).toEqual([{ property: 'rowCount', value: '7' }]);
+    expect(emitted).toEqual([{ property: 'rowCount', value: 7, isInputValid: true }]);
+  });
+
+  it('should refuse an emptied row count and put the box back', async () => {
+    const emitted: { property: string; value: unknown; isInputValid?: boolean | null }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    const input = inputs()[0];
+    input.nativeElement.value = '';
+    input.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(emitted).toEqual([]);
+
+    input.nativeElement.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual([{ property: 'rowCount', value: null, isInputValid: false }]);
+    expect(input.nativeElement.value).toBe('3');
   });
 
   it('should emit the toggled auto height', () => {
@@ -116,9 +147,10 @@ describe('MultiLineTextPropertiesComponent', () => {
   });
 
   // The math text area shares only rowCount and hasAutoHeight.
-  it('should show only the shared controls when the text-area-only ones are absent', () => {
+  it('should show only the shared controls when the text-area-only ones are absent', async () => {
     component.combinedProperties = { rowCount: 4, hasAutoHeight: false };
     fixture.detectChanges();
+    await fixture.whenStable(); // NgModel writes the box in a microtask
 
     expect(findCheckbox('hasDynamicRowCount')).toBeUndefined();
     expect(inputs().length).toBe(1);

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.spec.ts
@@ -164,4 +164,22 @@ describe('MultiLineTextPropertiesComponent', () => {
     expect(checkboxes().length).toBe(0);
     expect(inputs().length).toBe(0);
   });
+
+  /* `rowCount` becomes the `rows` attribute of the textarea, so a 0 or a negative one is not a
+     count at all. Nothing enforced that before (#1164). */
+  it('should refuse a row count below one', async () => {
+    const emitted: { property: string; value: unknown; isInputValid?: boolean | null }[] = [];
+    component.updateModel.subscribe(update => emitted.push(update));
+
+    const input = inputs()[0];
+    input.nativeElement.value = '0';
+    input.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    input.nativeElement.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual([{ property: 'rowCount', value: 0, isInputValid: false }]);
+    expect(input.nativeElement.value).toBe('3');
+  });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/multi-line-text-properties/multi-line-text-properties.component.ts
@@ -31,7 +31,8 @@ export class MultiLineTextPropertiesComponent {
   @Output() updateModel =
     new EventEmitter<{
       property: keyof PanelMultiLineTextProperties;
-      value: boolean | number | string;
+      value: boolean | number | string | null;
+      isInputValid?: boolean | null;
     }>();
 
   constructor(public unitService: UnitService) { }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/select-properties/select-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/select-properties/select-properties.component.html
@@ -49,11 +49,11 @@
 
   <mat-form-field appearance="fill">
     <mat-label>{{'itemsPerRow' | translate }}</mat-label>
-    <input #itemsPerRowField matInput type="number" [min]="1" [pattern]="'[1-9]'" #itemsPerRow="ngModel" required
+    <input matInput type="number" [min]="1" [pattern]="'[1-9]'" #itemsPerRow="ngModel" required aspectNumberField
            [disabled]="combinedProperties.itemsPerRow === null"
            [ngModel]="combinedProperties.itemsPerRow"
-           (input)="itemsPerRow.valid &&
-                    updateModel.emit({ property: 'itemsPerRow', value: itemsPerRowField.value })">
+           (numberChange)="updateModel.emit(
+                  { property: 'itemsPerRow', value: $event.value, isInputValid: $event.isInputValid })">
     @if (itemsPerRow.errors?.['pattern']) {
       <mat-error>{{'numberGreater0' | translate}}</mat-error>
     }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/select-properties/select-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/select-properties/select-properties.component.spec.ts
@@ -15,6 +15,10 @@ import {
 } from 'editor/src/app/modules/properties-panel/components/merged-checkbox/merged-checkbox.component';
 import { UnitService } from 'editor/src/app/services/unit.service';
 import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
+import {
   SelectPropertiesComponent
 } from './select-properties.component';
 
@@ -28,7 +32,10 @@ describe('SelectPropertiesComponent', () => {
     unitServiceMock = { expertMode: true };
 
     await TestBed.configureTestingModule({
-      declarations: [SelectPropertiesComponent, MergedCheckboxComponent],
+      declarations: [
+        SelectPropertiesComponent, MergedCheckboxComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective
+      ],
       imports: [
         CommonModule,
         FormsModule,

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/select-properties/select-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/select-properties/select-properties.component.ts
@@ -49,7 +49,8 @@ export class SelectPropertiesComponent {
   @Output() updateModel =
     new EventEmitter<{
       property: keyof PanelSelectProperties,
-      value: string | number | boolean | string[] | null
+      value: string | number | boolean | string[] | null,
+      isInputValid?: boolean | null
     }>();
 
   constructor(public unitService: UnitService) { }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
@@ -13,7 +13,8 @@
       <input matInput type="number" required [min]="maxRowIndex" aspectNumberField
              [ngModel]="combinedProperties.gridRowSizes.length"
              (click)="$event.stopPropagation()"
-             (numberChange)="commitCount('gridRowSizes', $event)">
+             (numberChange)="commitCount('gridRowSizes', $event)"
+             (blur)="applyCount('gridRowSizes')">
     </mat-form-field>
     @for (size of combinedProperties.gridRowSizes; track $index) {
       <aspect-size-input-panel [label]="('section-menu.height' | translate) + ' ' + ($index + 1)"
@@ -33,7 +34,8 @@
       <input matInput type="number" required [min]="maxColIndex" aspectNumberField
              [ngModel]="combinedProperties.gridColumnSizes.length"
              (click)="$event.stopPropagation()"
-             (numberChange)="commitCount('gridColumnSizes', $event)">
+             (numberChange)="commitCount('gridColumnSizes', $event)"
+             (blur)="applyCount('gridColumnSizes')">
     </mat-form-field>
     @for (size of combinedProperties.gridColumnSizes; track $index) {
       <aspect-size-input-panel [label]="('section-menu.width' | translate) + ' ' + ($index + 1)"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
@@ -10,10 +10,10 @@
     <legend>{{'section-menu.rows' | translate }}</legend>
     <mat-form-field appearance="outline">
       <mat-label>{{ 'section-menu.rowCount' | translate }}</mat-label>
-      <input matInput #rowCountField type="number" [min]="maxRowIndex"
-             [value]="combinedProperties.gridRowSizes.length"
+      <input matInput type="number" required [min]="maxRowIndex" aspectNumberField
+             [ngModel]="combinedProperties.gridRowSizes.length"
              (click)="$event.stopPropagation()"
-             (change)="modifySizeArray('gridRowSizes', +rowCountField.value || 0, $event)">
+             (numberChange)="commitCount('gridRowSizes', $event)">
     </mat-form-field>
     @for (size of combinedProperties.gridRowSizes; track $index) {
       <aspect-size-input-panel [label]="('section-menu.height' | translate) + ' ' + ($index + 1)"
@@ -30,10 +30,10 @@
     <legend>{{'section-menu.columns' | translate }}</legend>
     <mat-form-field appearance="outline">
       <mat-label>{{ 'section-menu.columnCount' | translate }}</mat-label>
-      <input matInput #columnCountField type="number" [min]="maxColIndex"
-             [value]="combinedProperties.gridColumnSizes.length"
+      <input matInput type="number" required [min]="maxColIndex" aspectNumberField
+             [ngModel]="combinedProperties.gridColumnSizes.length"
              (click)="$event.stopPropagation()"
-             (change)="modifySizeArray('gridColumnSizes', +columnCountField.value || 0, $event)">
+             (numberChange)="commitCount('gridColumnSizes', $event)">
     </mat-form-field>
     @for (size of combinedProperties.gridColumnSizes; track $index) {
       <aspect-size-input-panel [label]="('section-menu.width' | translate) + ' ' + ($index + 1)"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
@@ -21,6 +21,7 @@
                                [value]="size.value"
                                [unit]="size.unit"
                                [allowedUnits]="['px', 'fr']"
+                               [min]="0"
                                (valueUpdated)="changeGridSize('gridRowSizes', $index, $event)">
       </aspect-size-input-panel>
     }
@@ -42,6 +43,7 @@
                                [value]="size.value"
                                [unit]="size.unit"
                                [allowedUnits]="['px', 'fr']"
+                               [min]="0"
                                (valueUpdated)="changeGridSize('gridColumnSizes', $index, $event)">
       </aspect-size-input-panel>
     }

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.html
@@ -14,7 +14,8 @@
              [ngModel]="combinedProperties.gridRowSizes.length"
              (click)="$event.stopPropagation()"
              (numberChange)="commitCount('gridRowSizes', $event)"
-             (blur)="applyCount('gridRowSizes')">
+             (blur)="applyCount('gridRowSizes')"
+             (keydown.enter)="applyCount('gridRowSizes')">
     </mat-form-field>
     @for (size of combinedProperties.gridRowSizes; track $index) {
       <aspect-size-input-panel [label]="('section-menu.height' | translate) + ' ' + ($index + 1)"
@@ -36,7 +37,8 @@
              [ngModel]="combinedProperties.gridColumnSizes.length"
              (click)="$event.stopPropagation()"
              (numberChange)="commitCount('gridColumnSizes', $event)"
-             (blur)="applyCount('gridColumnSizes')">
+             (blur)="applyCount('gridColumnSizes')"
+             (keydown.enter)="applyCount('gridColumnSizes')">
     </mat-form-field>
     @for (size of combinedProperties.gridColumnSizes; track $index) {
       <aspect-size-input-panel [label]="('section-menu.width' | translate) + ' ' + ($index + 1)"

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
@@ -30,6 +30,7 @@ import {
 
 @Component({ selector: 'aspect-size-input-panel', standalone: false, template: '' })
 class MockSizeInputPanelComponent {
+  @Input() min: number | null = null;
   @Input() label!: string;
   @Input() value!: number;
   @Input() unit!: string;

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
@@ -6,6 +6,7 @@ import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -111,6 +112,17 @@ describe('TablePropertiesComponent', () => {
 
   it('should render a size input panel for every row and column', () => {
     expect(fixture.nativeElement.querySelectorAll('aspect-size-input-panel').length).toBe(5);
+  });
+
+  /* The shared panel takes its floor from the call site, because it also serves the margins, where
+     a negative measurement is meant. A grid track shorter than nothing is not a length (#1164). */
+  it('should give the size panels a floor of zero', () => {
+    const panels = fixture.debugElement.queryAll(By.directive(MockSizeInputPanelComponent));
+
+    expect(panels.length).toBe(5);
+    panels.forEach(panel => {
+      expect((panel.componentInstance as MockSizeInputPanelComponent).min).toBe(0);
+    });
   });
 
   // A selection of tables whose grids disagree merges the size arrays to null. A count field would

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
@@ -6,6 +6,7 @@ import {
   Component, EventEmitter, Input, Output
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -19,6 +20,10 @@ import {
 import { ElementService } from 'editor/src/app/services/element.service';
 import { MessageService } from 'editor/src/app/services/message.service';
 import { UnitService } from 'editor/src/app/services/unit.service';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import {
   TablePropertiesComponent
 } from './table-properties.component';
@@ -40,22 +45,19 @@ describe('TablePropertiesComponent', () => {
   let tablePropUpdated: Subject<string>;
   let emitted: { property: string; value: unknown }[];
 
-  interface InputEventTargetMock { checkValidity: () => boolean; value: string | number }
-
-  const createChangeEvent = (valid: boolean, value: string): { event: Event, target: InputEventTargetMock } => {
-    const target: InputEventTargetMock = { checkValidity: () => valid, value };
-    return { event: { target } as unknown as Event, target };
-  };
-
   beforeEach(async () => {
     elementService = createSpyObj<ElementService>(['showDefaultEditDialog']);
     messageService = createSpyObj<MessageService>(['showError']);
     tablePropUpdated = new Subject<string>();
 
     await TestBed.configureTestingModule({
-      declarations: [TablePropertiesComponent, MockSizeInputPanelComponent, MergedCheckboxComponent],
+      declarations: [
+        TablePropertiesComponent, MockSizeInputPanelComponent, MergedCheckboxComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective
+      ],
       imports: [
         CommonModule,
+        FormsModule,
         MatButtonModule,
         MatCheckboxModule,
         MatFormFieldModule,
@@ -126,7 +128,7 @@ describe('TablePropertiesComponent', () => {
   });
 
   it('should append new default sizes when the row count grows', () => {
-    component.modifySizeArray('gridRowSizes', 3, createChangeEvent(true, '3').event);
+    component.modifySizeArray('gridRowSizes', 3);
 
     expect(emitted).toEqual([{
       property: 'gridRowSizes',
@@ -135,21 +137,56 @@ describe('TablePropertiesComponent', () => {
   });
 
   it('should cut off sizes when the column count shrinks', () => {
-    component.modifySizeArray('gridColumnSizes', 1, createChangeEvent(true, '1').event);
+    component.modifySizeArray('gridColumnSizes', 1);
 
     expect(emitted).toEqual([{ property: 'gridColumnSizes', value: [{ value: 1, unit: 'fr' }] }]);
   });
 
-  it('should refuse an invalid size count and show an error message', () => {
-    const { event, target } = createChangeEvent(false, '0');
+  /* The two count fields go through `aspectNumberField` now, so these go through the boxes: what is
+     left in the component is the decision what to do with a refusal, and the wiring is what used to
+     be wrong. `min` is bound to the highest row or column a child element sits in. */
+  describe('the count fields', () => {
+    const rowCount = (): HTMLInputElement => fixture.nativeElement
+      .querySelector('input[type="number"]') as HTMLInputElement;
 
-    component.modifySizeArray('gridRowSizes', 0, event);
+    const edit = async (box: HTMLInputElement, value: string): Promise<void> => {
+      box.value = value;
+      box.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      box.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
 
-    // The message goes through TranslateService now; with no translations loaded it yields the key.
-    expect(messageService.showError)
-      .toHaveBeenCalledWith('propertiesPanel.sizeArrayNotEmptyRow');
-    expect(emitted).toEqual([]);
-    expect(target.value).toBe(2);
+    it('should take a count that clears the elements in the table', async () => {
+      await edit(rowCount(), '3');
+
+      expect(emitted).toEqual([{
+        property: 'gridRowSizes',
+        value: [{ value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }, { value: 1, unit: 'fr' }]
+      }]);
+    });
+
+    /* The row count may not drop below the last row that still holds an element. This worked before
+       through `checkValidity()` and works now through the bound `min`. */
+    it('should refuse a count that would drop an occupied row', async () => {
+      await edit(rowCount(), '1');
+
+      expect(emitted).toEqual([]);
+      expect(messageService.showError).toHaveBeenCalledWith('propertiesPanel.sizeArrayNotEmptyRow');
+      expect(rowCount().value).toBe('2');
+    });
+
+    /* And the hole that was left: an empty number input has no range underflow, so it passed
+       `checkValidity()` as valid, and the size array was cut to nothing - every row of the table
+       gone, silently and with no message (#1164). */
+    it('should refuse an emptied count rather than drop every row', async () => {
+      await edit(rowCount(), '');
+
+      expect(emitted).toEqual([]);
+      expect(messageService.showError).toHaveBeenCalledWith('inputInvalid');
+      expect(rowCount().value).toBe('2');
+    });
   });
 
   it('should emit the changed size of a single column', () => {

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.spec.ts
@@ -177,6 +177,32 @@ describe('TablePropertiesComponent', () => {
       expect(rowCount().value).toBe('2');
     });
 
+    /* Every two-digit entry passes through a single digit first. Applying that digit cut the size
+       array down to it, and raising it again filled the gap with default tracks - so typing 12 over
+       a 2 lost the second row's height. The count is applied on leaving the field now, which is
+       where the original handler had it. */
+    it('should not cut the size array while a two-digit count is being typed', async () => {
+      component.combinedProperties = {
+        ...component.combinedProperties,
+        elements: [{ gridRow: 1, gridColumn: 1 }] as never,
+        gridRowSizes: [{ value: 200, unit: 'px' }, { value: 300, unit: 'px' }]
+      };
+      component.calculateMaxIndices();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      rowCount().value = '1';
+      rowCount().dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      expect(emitted).toEqual([]); // nothing applied while it is being typed
+
+      await edit(rowCount(), '12');
+
+      expect(emitted.length).toBe(1);
+      expect((emitted[0].value as { value: number; unit: string }[]).slice(0, 2))
+        .toEqual([{ value: 200, unit: 'px' }, { value: 300, unit: 'px' }]);
+    });
+
     /* And the hole that was left: an empty number input has no range underflow, so it passed
        `checkValidity()` as valid, and the size array was cut to nothing - every row of the table
        gone, silently and with no message (#1164). */

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.ts
@@ -27,6 +27,9 @@ export class TablePropertiesComponent implements OnInit, OnDestroy {
   maxRowIndex!: number;
   maxColIndex!: number;
 
+  /** The last valid entry per count box, applied when that field is left. */
+  private pendingCount: Partial<Record<'gridColumnSizes' | 'gridRowSizes', number>> = {};
+
   constructor(public elementService: ElementService,
               private messageService: MessageService,
               private unitService: UnitService,
@@ -75,9 +78,28 @@ export class TablePropertiesComponent implements OnInit, OnDestroy {
             'propertiesPanel.sizeArrayNotEmptyColumn' :
             'propertiesPanel.sizeArrayNotEmptyRow')
       ));
+      delete this.pendingCount[property];
       return;
     }
-    this.modifySizeArray(property, update.value);
+    this.pendingCount[property] = update.value;
+  }
+
+  /**
+   * The count is applied on leaving the field, not on the keystroke.
+   *
+   * Every two-digit entry passes through a single digit first, and applying that digit cuts the
+   * size array down to it - so typing 12 over a 2 dropped the second row's height and came back
+   * with ten default tracks instead. The original handler was on `(change)`, i.e. here; the
+   * migration is what moved it to the keystroke (#1164).
+   *
+   * The directive's own blur listener runs first (measured), so a refused entry has already cleared
+   * what was pending by the time this asks.
+   */
+  applyCount(property: 'gridColumnSizes' | 'gridRowSizes'): void {
+    const pending = this.pendingCount[property];
+    if (pending === undefined) return;
+    delete this.pendingCount[property];
+    this.modifySizeArray(property, pending);
   }
 
   /* Add or remove elements to size array. Default value 1fr. */

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/table-properties/table-properties.component.ts
@@ -53,17 +53,35 @@ export class TablePropertiesComponent implements OnInit, OnDestroy {
     this.maxColIndex = Math.max(...elements.map(el => el.gridColumn), 1);
   }
 
-  /* Add or remove elements to size array. Default value 1fr. */
-  modifySizeArray(property: 'gridColumnSizes' | 'gridRowSizes', newLength: number, event?: Event): void {
-    if (!(event?.target as HTMLInputElement).checkValidity()) {
-      (event as any).target.value = (this.combinedProperties[property] as unknown[]).length;
+  /**
+   * What `aspectNumberField` worked out for one of the two count fields.
+   *
+   * The guard used to be written out here, reading `checkValidity()` off the event and putting the
+   * box back by hand. It caught a count below `min` - a row that still holds elements - but not an
+   * emptied box: an empty number input has no range underflow, so it passed as valid and the whole
+   * size array was cut to nothing, silently and without a message (#1164).
+   *
+   * `required` closes that, and the two refusals want different words. `min` is about this table -
+   * the row you are trying to drop still has something in it - while an empty box is simply not a
+   * count. They are told apart by the value: a box refused for being empty carries null.
+   */
+  commitCount(property: 'gridColumnSizes' | 'gridRowSizes',
+              update: { value: number | null; isInputValid: boolean }): void {
+    if (!update.isInputValid || update.value === null) {
       this.messageService.showError(this.translateService.instant(
-        property === 'gridColumnSizes' ?
-          'propertiesPanel.sizeArrayNotEmptyColumn' :
-          'propertiesPanel.sizeArrayNotEmptyRow'
+        // eslint-disable-next-line no-nested-ternary
+        update.value === null ? 'inputInvalid' :
+          (property === 'gridColumnSizes' ?
+            'propertiesPanel.sizeArrayNotEmptyColumn' :
+            'propertiesPanel.sizeArrayNotEmptyRow')
       ));
       return;
     }
+    this.modifySizeArray(property, update.value);
+  }
+
+  /* Add or remove elements to size array. Default value 1fr. */
+  modifySizeArray(property: 'gridColumnSizes' | 'gridRowSizes', newLength: number): void {
     const sizeArray: { value: number; unit: string }[] = property === 'gridColumnSizes' ?
       (this.combinedProperties.gridColumnSizes as { value: number; unit: string }[]) :
       (this.combinedProperties.gridRowSizes as { value: number; unit: string }[]);

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.html
@@ -11,9 +11,10 @@
   <mat-form-field *ngIf="combinedProperties.columnCount != null"
                   appearance="fill">
     <mat-label>{{ 'propertiesPanel.columnCount' | translate }}</mat-label>
-    <input #columnCountField matInput type="number" [value]="combinedProperties.columnCount"
-           (input)="columnCountField.value !== '' && emitOwn('columnCount', +columnCountField.value)"
-           (change)="columnCountField.value === '' && emitOwn('columnCount', 0)">
+    <input matInput type="number" required aspectNumberField
+           [ngModel]="combinedProperties.columnCount"
+           (numberChange)="updateModel.emit(
+                  { property: 'columnCount', value: $event.value, isInputValid: $event.isInputValid })">
   </mat-form-field>
 
   <fieldset class="fx-column-start-stretch">

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.html
@@ -11,7 +11,7 @@
   <mat-form-field *ngIf="combinedProperties.columnCount != null"
                   appearance="fill">
     <mat-label>{{ 'propertiesPanel.columnCount' | translate }}</mat-label>
-    <input matInput type="number" required aspectNumberField
+    <input matInput type="number" min="1" required aspectNumberField
            [ngModel]="combinedProperties.columnCount"
            (numberChange)="updateModel.emit(
                   { property: 'columnCount', value: $event.value, isInputValid: $event.isInputValid })">

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.spec.ts
@@ -27,6 +27,10 @@ import { DialogService } from 'editor/src/app/services/dialog.service';
 import { SelectionService } from 'editor/src/app/services/selection.service';
 import { UnitService } from 'editor/src/app/services/unit.service';
 import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
+import {
   TextPropsComponent
 } from './text-properties-field-set.component';
 
@@ -61,8 +65,8 @@ describe('TextPropsComponent', () => {
       declarations: [TextPropsComponent,
         MockHighlightPropertiesComponent,
         SafeResourceHTMLPipe,
-        MergedCheckboxComponent
-      ],
+        MergedCheckboxComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective],
       imports: [
         CommonModule,
         FormsModule,
@@ -148,22 +152,27 @@ describe('TextPropsComponent', () => {
     const columnCountInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
     columnCountInput.value = '3';
     columnCountInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
 
-    expect(emitted).toEqual([{ property: 'columnCount', value: 3 }]);
+    expect(emitted).toEqual([{ property: 'columnCount', value: 3, isInputValid: true }]);
   });
 
-  /* Empty means zero, committed on leaving the field. Emitting while typing would write over the
-     box; the old `(change)` handler patched only the merged object, so the panel showed 0 while
-     the saved unit definition kept what the emit had put there. */
-  it('should emit zero for a column count left empty', () => {
+  /* This box kept the last hand-written copy of the old rule: a `(change)` handler that wrote a 0
+     for an emptied field. `columnCount` is declared `number`, so it is `required` now and an empty
+     box is refused like everywhere else (#1164). */
+  it('should refuse a column count left empty', async () => {
     const columnCountInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
 
     columnCountInput.value = '';
     columnCountInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
     expect(emitted).toEqual([]);
 
-    columnCountInput.dispatchEvent(new Event('change'));
+    columnCountInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
 
-    expect(emitted).toEqual([{ property: 'columnCount', value: 0 }]);
+    expect(emitted).toEqual([{ property: 'columnCount', value: null, isInputValid: false }]);
+    expect(columnCountInput.value).toBe('1');
   });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.spec.ts
@@ -175,4 +175,19 @@ describe('TextPropsComponent', () => {
     expect(emitted).toEqual([{ property: 'columnCount', value: null, isInputValid: false }]);
     expect(columnCountInput.value).toBe('1');
   });
+
+  /* `columnCount` becomes the CSS `column-count`, where a 0 is not a count (#1164). */
+  it('should refuse a column count below one', async () => {
+    const columnCountInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+
+    columnCountInput.value = '0';
+    columnCountInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    columnCountInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual([{ property: 'columnCount', value: 0, isInputValid: false }]);
+    expect(columnCountInput.value).toBe('1');
+  });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/text-properties-field-set/text-properties-field-set.component.ts
@@ -24,7 +24,7 @@ export class TextPropsComponent {
   @Output() updateModel =
     new EventEmitter<{
       property: keyof TextProperties;
-      value: string | number | boolean | string[],
+      value: string | number | boolean | string[] | null,
       isInputValid?: boolean | null
     }>();
 

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/widget-periodic-table-properties/widget-periodic-table-properties.component.html
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/widget-periodic-table-properties/widget-periodic-table-properties.component.html
@@ -20,10 +20,10 @@
 
     <mat-form-field appearance="fill">
       <mat-label>{{'propertiesPanel.maxNumberOfSelections' | translate }}</mat-label>
-      <input #maxNumberOfSelectionsField matInput type="number" min="0"
-         [value]="combinedProperties.maxNumberOfSelections"
-         (input)="updateModel
-           .emit({ property: 'maxNumberOfSelections', value: maxNumberOfSelectionsField.value || 0 })">
+      <input matInput type="number" min="0" required aspectNumberField
+             [ngModel]="combinedProperties.maxNumberOfSelections"
+             (numberChange)="updateModel.emit(
+                    { property: 'maxNumberOfSelections', value: $event.value, isInputValid: $event.isInputValid })">
     </mat-form-field>
   </div>
 </fieldset>

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/widget-periodic-table-properties/widget-periodic-table-properties.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/widget-periodic-table-properties/widget-periodic-table-properties.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -6,6 +7,10 @@ import { TranslateModule } from '@ngx-translate/core';
 import {
   MergedCheckboxComponent
 } from 'editor/src/app/modules/properties-panel/components/merged-checkbox/merged-checkbox.component';
+import {
+  NumberFieldBadInputDirective
+} from 'editor/modules/editor-shared/directives/number-field-bad-input.directive';
+import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/number-field.directive';
 import {
   WidgetPeriodicTablePropertiesComponent
 } from './widget-periodic-table-properties.component';
@@ -17,8 +22,12 @@ describe('WidgetPeriodicTablePropertiesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [WidgetPeriodicTablePropertiesComponent, MergedCheckboxComponent],
+      declarations: [
+        WidgetPeriodicTablePropertiesComponent, MergedCheckboxComponent,
+        NumberFieldDirective, NumberFieldBadInputDirective
+      ],
       imports: [
+        FormsModule,
         MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
@@ -61,19 +70,31 @@ describe('WidgetPeriodicTablePropertiesComponent', () => {
     expect(emitted).toEqual([{ property: 'showInfoENeg', value: true }]);
   });
 
-  it('should emit the maximum number of selections', () => {
+  /* `maxNumberOfSelections` is declared `number`, and the box handed on `field.value` - the raw
+     string (#1164). */
+  it('should emit the maximum number of selections as a number', () => {
     const numberInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
     numberInput.value = '5';
     numberInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
 
-    expect(emitted).toEqual([{ property: 'maxNumberOfSelections', value: '5' }]);
+    expect(emitted).toEqual([{ property: 'maxNumberOfSelections', value: 5, isInputValid: true }]);
   });
 
-  it('should fall back to zero for an empty maximum number of selections', () => {
+  /* An emptied box used to write a 0 on the keystroke that emptied it - so clearing the field to
+     retype set "no selection allowed" in passing. It is refused on leaving now. */
+  it('should refuse an emptied maximum number of selections', async () => {
     const numberInput = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
     numberInput.value = '';
     numberInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(emitted).toEqual([]);
 
-    expect(emitted).toEqual([{ property: 'maxNumberOfSelections', value: 0 }]);
+    numberInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(emitted).toEqual([{ property: 'maxNumberOfSelections', value: null, isInputValid: false }]);
+    expect(numberInput.value).toBe('3');
   });
 });

--- a/projects/editor/src/app/modules/properties-panel/components/element-model-properties/widget-periodic-table-properties/widget-periodic-table-properties.component.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/element-model-properties/widget-periodic-table-properties/widget-periodic-table-properties.component.ts
@@ -12,5 +12,9 @@ import { Merged } from 'editor/src/app/modules/properties-panel/models/merged-pr
 export class WidgetPeriodicTablePropertiesComponent {
   @Input() combinedProperties!: Merged<WidgetPeriodicTableProperties>;
   @Output() updateModel =
-    new EventEmitter<{ property: keyof WidgetPeriodicTableProperties; value: string | number | boolean | null }>();
+    new EventEmitter<{
+      property: keyof WidgetPeriodicTableProperties;
+      value: string | number | boolean | null;
+      isInputValid?: boolean | null
+    }>();
 }

--- a/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
+++ b/projects/editor/src/app/modules/properties-panel/components/position-field-set/position-field-set.component.spec.ts
@@ -23,6 +23,7 @@ import { NumberFieldDirective } from 'editor/modules/editor-shared/directives/nu
   template: ''
 })
 class MockSizeInputPanelComponent {
+  @Input() min: number | null = null;
   @Input() label!: string;
   @Input() value: number | null | undefined;
   @Input() unit: string | null | undefined;


### PR DESCRIPTION
Refs #1164, refs #1148. Schließt an PR #1163 und #1165 an: dort sind 42 der 65 Zahlenfelder des Editors auf `aspectNumberField` umgestellt worden, hier folgen die verbliebenen 23.

## Was an ihnen falsch war

Vier Muster, alle seit Jahren in Produktion:

- **Rohe Strings in `number`-Eigenschaften.** Acht Felder reichten `field.value` bzw. `$event.target.value` unverwandelt weiter, die Aufgabendatei enthielt dann `"5"` statt `5`.
- **`min`/`max` ohne Wirkung.** Ohne `ngModel` entsteht aus `[min]` kein Validator, sondern nur ein Attribut. Beim Seitenverhältnis im Seitenmenü gab es zwar eine Prüfung, aber die Gültigkeit wurde nicht weitergereicht — 150 wurde gespeichert und behalten.
- **`|| 0` pro Tastendruck.** Die Regel, die #1161 abgeschafft hat, hier noch elfmal: ein Feld, das der Browser gerade nicht lesen kann, meldet leer, also schrieb das Leeren zum Neutippen erst eine 0. Bei der maximalen Abspielhäufigkeit bedeutet diese 0 im Player „unbegrenzt", das Gegenteil der Eingabe.
- **Zwei Fälle mit Datenverlust.** Die Zeilen-/Spaltenanzahl von Tabelle und Abschnitt kürzt das Größen-Array. Ein geleertes Feld ließ von der Tabelle keine Zeile übrig — wortlos.

## Was beim Umsetzen gemessen wurde

- **Bei der Tabelle wirkte `[min]` doch** — über die native `checkValidity()`, die der Handler abfragte. Die Lücke war enger: ein leeres Zahlenfeld hat keinen Range-Underflow, geht also als gültig durch. Die Ticketbeschreibung ist entsprechend korrigiert.
- **Zweistellige Eingaben liefen durch eine gültige einstellige.** Weil die Migration den Commit vom Verlassen auf den Tastendruck verlegt hatte, wurde diese Ziffer sofort angewandt: „15" über einer „5" ließ von fünf getippten Teilfragen eine übrig und setzte das Feld auf 1 statt zurück auf 5. Betrifft drei Felder; alle merken sich jetzt die letzte gültige Eingabe und wenden sie beim Verlassen an, wo die ursprünglichen Handler saßen.
- **Enter schrieb nicht mehr.** `(change)` feuert auch bei Enter, `blur` nicht. Alle sechs aufschiebenden Felder reagieren jetzt zusätzlich auf Enter.
- **Ein `(numberChange)` ohne verfügbare Direktive wirft nicht.** Angular hält es für einen Listener auf ein Custom Event; das Feld tut dann stillschweigend nichts. Zwei Specs waren dadurch grün gegen ein totes Feld. Alle Specs deklarieren die Direktive jetzt und fahren die echte Box, und die Modul-Verdrahtung ist für jede Aufrufstelle geprüft.

## Entscheidungen, die im Ticket standen

- **Untergrenzen** an den vier bis dahin unbegrenzten Feldern (`min="1"`), jeweils am Verwendungsort geprüft: `rows`-Attribut, CSS `column-count`, `grid-template-columns`, berechnete Zeilenzahl.
- **Die gemeinsame Maß-Eingabe** bekommt ihre Untergrenze von der Aufrufstelle: Rasterspuren `0`, Ränder keine — ein negativer Rand zieht das Element heran und ist gewollt, eine negative Spurgröße ist keine Länge. Ihr bestehendes „schreibt nichts, solange eine Hälfte fehlt" bleibt unangetastet.
- **Nicht angefasst:** dass sich das Abschnittsraster über ein Element hinweg verkleinern lässt (die Tabelle verhindert das, der Abschnitt nicht). Das ist so alt wie das Feld, steht auch in `master`, und die Sperre wäre wirkungslos — über die automatische Zeilenhöhe ist derselbe Zustand ohne das Zählfeld erreichbar.

## Erledigt #1148 mit

Beim Zusammentragen aufgefallen: die sechs Felder, die #1148 als „speichern Strings statt Zahlen“ auflistet — `firstColumnSizeRatio`, `rowCount`, `expectedCharactersCount`, `itemsPerRow`, `columnCount`, `maxNumberOfSelections` — sind genau die, die hier auf die Direktive umgestellt werden. Sie schreiben jetzt Zahlen.

**Ein Rest daraus bleibt offen:** #1148 hält fest, dass vor der Änderung zu prüfen sei, ob bereits gespeicherte Aufgaben String-Werte enthalten und ob beim Laden normalisiert werden sollte. `model-normalizer.ts` wandelt keine dieser sechs Eigenschaften um — dieser PR stoppt also den Nachschub, räumt aber Bestandsdaten nicht auf. Bewusst nicht mit erledigt, weil es eine Frage an die Verbraucher der Definition ist (Player, Schema-Validierung, Auswertung) und nicht an das Eingabefeld.

## Prüfung

Alle fünf Testprojekte grün (2311), Lint und Production-Build sauber. Jede Verhaltensänderung ist per Mutation belegt: Änderung zurückgedreht, geprüft dass genau der zuständige Test rot wird. Zwei Code-Reviews sind eingearbeitet.

## Offen

Die UI-Sichtung: `required` lässt Material ein Sternchen am Label rendern, jetzt auch in den Assistenten-Dialogen, im Bild-Dialog, im Seiten- und Abschnittsmenü und an den Maßfeldern. Für den Eigenschaftenbereich war das mit #1161 abgenommen, diese Fläche ist neu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

